### PR TITLE
Add farm summary CSV export

### DIFF
--- a/public/export.js
+++ b/public/export.js
@@ -24,6 +24,49 @@ export function exportTableToCSV(tableId, baseName = 'table') {
 }
 window.exportTableToCSV = exportTableToCSV;
 
+export function exportFarmSummaryCSV() {
+    const tables = [
+        ['stationShearerTable', 'Shearer Summary'],
+        ['stationStaffTable', 'Shed Staff'],
+        ['stationLeaderTable', 'Team Leaders'],
+        ['stationCombTable', 'Comb Types'],
+        ['stationTotalTable', 'Totals']
+    ];
+
+    const rows = [];
+    const appendTable = (id, title) => {
+        const table = document.getElementById(id);
+        if (!table) return;
+        if (rows.length) rows.push([]);
+        rows.push([title]);
+        table.querySelectorAll('tr').forEach(tr => {
+            const cols = Array.from(tr.querySelectorAll('th,td'))
+                .map(td => td.textContent.trim());
+            rows.push(cols);
+        });
+    };
+    tables.forEach(t => appendTable(t[0], t[1]));
+
+    const csv = rows.map(r => r.map(v => `"${v.replace(/"/g, '""')}"`).join(','))
+        .join('\r\n');
+
+    const farmName = document.getElementById('stationSelect')?.value.trim() || 'FarmSummary';
+    const date = new Date();
+    const formatted = date.toLocaleDateString('en-NZ').replace(/\//g, '-');
+    const fileName = `FarmSummary_${farmName}_${formatted}.csv`;
+
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = fileName;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+}
+window.exportFarmSummaryCSV = exportFarmSummaryCSV;
+
 export function exportDailySummaryCSV() {
     const data = collectExportData();
 

--- a/public/tally.js
+++ b/public/tally.js
@@ -1955,8 +1955,7 @@ const interceptReset = (full) => (e) => {
 
     const exportBtn = document.getElementById('exportFarmSummaryBtn');
     exportBtn?.addEventListener('click', () => {
-        const farmName = document.getElementById('stationName')?.value.trim() || 'FarmSummary';
-        exportTableToCSV('stationSummaryTable', `FarmSummary_${farmName}`);
+        exportFarmSummaryCSV();
     });
 
     document.addEventListener('focusin', (e) => {


### PR DESCRIPTION
## Summary
- add `exportFarmSummaryCSV` to combine all Farm Summary tables
- invoke `exportFarmSummaryCSV` from the Farm Summary export button

## Testing
- `node --version`
- `npm install jsdom` *(fails: unable to access registry)*

------
https://chatgpt.com/codex/tasks/task_e_68838a20c78c83218af9de9916c5c677