### PR TITLE
Fix duplicate exportFarmSummaryCSV

### DIFF
--- a/public/export.js
+++ b/public/export.js
@@ -34,51 +34,6 @@ export function exportFarmSummaryCSV() {
     ];
 
     const rows = [];
-    tables.forEach(([id, title], idx) => {
-        const table = document.getElementById(id);
-        if (!table) return;
-        rows.push([title]);
-        table.querySelectorAll('tr').forEach(tr => {
-            const cols = Array.from(tr.querySelectorAll('th,td'))
-                .map(td => td.textContent.trim());
-            rows.push(cols);
-        });
-        if (idx < tables.length - 1) {
-            rows.push([]);
-            rows.push([]);
-        }
-    });
-
-    const csv = rows.map(r => r.map(v => `"${v.replace(/"/g, '""')}"`).join(','))
-        .join('\r\n');
-
-    const farmName = document.getElementById('stationSelect')?.value.trim() || 'FarmSummary';
-    const date = new Date();
-    const formatted = date.toLocaleDateString('en-NZ').replace(/\//g, '-');
-    const fileName = `FarmSummary_${farmName}_${formatted}.csv`;
-
-    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = fileName;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
-}
-window.exportFarmSummaryCSV = exportFarmSummaryCSV;
-
-export function exportFarmSummaryCSV() {
-    const tables = [
-        ['stationShearerTable', 'Shearer Summary'],
-        ['stationStaffTable', 'Shed Staff'],
-        ['stationLeaderTable', 'Team Leaders'],
-        ['stationCombTable', 'Comb Types'],
-        ['stationTotalTable', 'Totals']
-    ];
-
-    const rows = [];
     const appendTable = (id, title) => {
         const table = document.getElementById(id);
         if (!table) return;


### PR DESCRIPTION
## Summary
- remove the duplicate exportFarmSummaryCSV function
- ensure only one exportFarmSummaryCSV is available

## Testing
- `node --check public/export.js`

------
https://chatgpt.com/codex/tasks/task_e_6883916d868c8321966f4bb9102b001c