### PR TITLE
Add Cloud Save Session button

### DIFF
--- a/public/tally.html
+++ b/public/tally.html
@@ -121,6 +121,7 @@
 </table>
 <div class="button-row">
     <button id="saveButton" onclick="saveData()">Save</button>
+    <button class="main-button" onclick="saveSessionToFirestore()">🔄 Cloud Save Session</button>
     <button id="loadSessionBtn">Load Session</button>
     <button onclick="restoreTodaySession()">Return to Today’s Session</button>
     <button onclick="showExportPrompt()">Export Data</button>


### PR DESCRIPTION
## Summary
- add a `🔄 Cloud Save Session` button next to the manual save options

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884b0914364832187321d6532bcb521