### PR TITLE
Fix Firestore missing in tally page

### DIFF
--- a/public/tally.html
+++ b/public/tally.html
@@ -7,8 +7,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>SHEAR iQ Tally Processor</title>
 <link rel="stylesheet" href="styles.css">
-   <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
   <script src="firebase-init.js"></script>
   <!-- PWA Manifest -->
     <link rel="manifest" href="manifest.json" />


### PR DESCRIPTION
## Summary
- load `firebase-firestore-compat.js` in `tally.html`

## Testing
- `npm test` *(fails: Missing script)*
- `node public/firestore-test.js` *(fails to connect: 14 UNAVAILABLE)*

------
https://chatgpt.com/codex/tasks/task_e_6884b34e56e883218aef1aea3f90195a