### PR TITLE
Add save options modal

### DIFF
--- a/public/tally.html
+++ b/public/tally.html
@@ -393,6 +393,18 @@ document.addEventListener('DOMContentLoaded', function () {
 });
 </script>
 
+<!-- Save Options Modal -->
+<div id="saveOptionsModal" class="modal-overlay">
+  <div class="modal-box">
+    <h3>Save Session</h3>
+    <div class="modal-buttons">
+      <button id="saveLocalBtn">📁 Save to Device</button>
+      <button id="saveCloudBtn">☁️ Save to Cloud</button>
+      <button id="saveBothBtn">🔄 Save to Both</button>
+    </div>
+  </div>
+</div>
+
 <script type="module">
 import { buildStationSummary, clearStationSummaryView } from './tally.js';
 window.clearStationSummaryView = clearStationSummaryView;


### PR DESCRIPTION
## Summary
- add Save Options modal in `tally.html`
- provide button handlers to save to local storage, Firestore, or both
- update `saveData` logic to use the modal
- adjust unsaved session flows to wait for save to finish

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6884c2f81ffc8321a4dd86b0d2f51f0c