### PR TITLE
Add load options modal

### DIFF
--- a/public/tally.html
+++ b/public/tally.html
@@ -395,6 +395,17 @@ document.addEventListener('DOMContentLoaded', function () {
 });
 </script>
 
+<!-- Load Options Modal -->
+<div id="loadOptionsModal" class="modal-overlay" style="display:none;">
+  <div class="modal-box">
+    <h3>Where do you want to load from?</h3>
+    <div class="modal-buttons">
+      <button id="loadLocalBtn">📁 Load from Device</button>
+      <button id="loadCloudBtn">☁️ Load from Cloud</button>
+    </div>
+  </div>
+</div>
+
 <!-- Save Options Modal -->
 <div id="saveOptionsModal" class="modal-overlay">
   <div class="modal-box">

--- a/public/tally.js
+++ b/public/tally.js
@@ -481,7 +481,17 @@ function hideLoadSessionModal() {
     const modal = document.getElementById('loadSessionModal');
     if (modal) modal.style.display = 'none';
 }
- 
+
+function showLoadOptionsModal() {
+    const modal = document.getElementById('loadOptionsModal');
+    if (modal) modal.style.display = 'flex';
+}
+
+function hideLoadOptionsModal() {
+    const modal = document.getElementById('loadOptionsModal');
+    if (modal) modal.style.display = 'none';
+}
+
 function showSetupModal() {
     const modal = document.getElementById('setupModal');
     if (modal) modal.style.display = 'flex';
@@ -1959,6 +1969,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const saveLocalBtn = document.getElementById('saveLocalBtn');
     const saveCloudBtn = document.getElementById('saveCloudBtn');
     const saveBothBtn = document.getElementById('saveBothBtn');
+    const loadLocalBtn = document.getElementById('loadLocalBtn');
+    const loadCloudBtn = document.getElementById('loadCloudBtn');
     if (!layoutBuilt && !getLastSession()) {
     window.awaitingSetupPrompt = true;
   }
@@ -1981,7 +1993,15 @@ const interceptReset = (full) => (e) => {
 
 
 
-    loadBtn?.addEventListener('click', showLoadSessionModal);
+    loadBtn?.addEventListener('click', showLoadOptionsModal);
+    loadLocalBtn?.addEventListener('click', () => {
+        hideLoadOptionsModal();
+        showLoadSessionModal();
+    });
+    loadCloudBtn?.addEventListener('click', () => {
+        hideLoadOptionsModal();
+        alert('Cloud loading coming soon.');
+    });
     cancelBtn?.addEventListener('click', hideLoadSessionModal);
     lastBtn?.addEventListener('click', () => {
         const session = getLastSession();


### PR DESCRIPTION
## Summary
- add new `loadOptionsModal` with two buttons for local or cloud loading
- implement show/hide logic in `tally.js`
- hook up Load Session button to open the modal and wire button actions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6884c90585108321bd2dba6d285119c1