### PR TITLE
Add autosave status indicator

### DIFF
--- a/public/tally.html
+++ b/public/tally.html
@@ -444,5 +444,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 </script>
 
+<div id="autosaveStatus" style="display:none; position:fixed; bottom:10px; right:10px; background:#222; color:#fff; padding:4px 8px; border-radius:4px; font-size:14px;"></div>
+
 </body>
 </html>

--- a/public/tally.js
+++ b/public/tally.js
@@ -145,6 +145,19 @@ let lastSavedJson = '';
 let lastLocalSave = 0;
 let lastCloudSave = 0;
 
+let autosaveHideTimer = null;
+
+function showAutosaveStatus(message) {
+    const el = document.getElementById('autosaveStatus');
+    if (!el) return;
+    el.innerText = message;
+    el.style.display = 'block';
+    if (autosaveHideTimer) clearTimeout(autosaveHideTimer);
+    autosaveHideTimer = setTimeout(() => {
+        el.style.display = 'none';
+    }, 3000);
+}
+
 function scheduleAutosave() {
     if (autosaveTimer) clearTimeout(autosaveTimer);
     autosaveTimer = setTimeout(() => {
@@ -157,6 +170,7 @@ function scheduleAutosave() {
             performSave(true, false);
             lastLocalSave = now;
             saved = true;
+            showAutosaveStatus("\ud83d\udcbe Autosaved locally");
         }
         if (now - lastCloudSave >= 10000) {
             saveSessionToFirestore();
@@ -1856,6 +1870,7 @@ export async function saveSessionToFirestore() {
 
         console.log('✅ Session saved to Firestore:', id);
         alert('✅ Session saved to the cloud!');
+        showAutosaveStatus('\u2601\ufe0f Autosaved to cloud');
     } catch (err) {
         console.error('❌ Failed to save session to Firestore:', err);
     }


### PR DESCRIPTION
## Summary
- add a hidden `#autosaveStatus` div to show autosave messages
- implement `showAutosaveStatus` helper in `tally.js`
- display an autosave message after local autosave
- show a cloud autosave message when saving to Firestore

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6884d1674d048321bb9d37425a501627