### PR TITLE
Add manual flag to saveData

### DIFF
--- a/public/tally.html
+++ b/public/tally.html
@@ -121,7 +121,7 @@
   </tbody>
 </table>
 <div class="button-row">
-    <button id="saveButton" onclick="saveData()">Save</button>
+    <button id="saveButton" onclick="saveData(true)">Save</button>
     <button id="loadSessionBtn">Load Session</button>
     <button onclick="restoreTodaySession()">Return to Today’s Session</button>
     <button onclick="showExportPrompt()">Export Data</button>


### PR DESCRIPTION
## Summary
- add `manual` parameter to `saveData` and update logic
- suppress save popup during autosave
- update save button and prompts to use `saveData(true)`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6884d61aedec8321a18ee7ee241c8993