### PR TITLE
Load sessions per user path

### DIFF
--- a/public/tally.js
+++ b/public/tally.js
@@ -1872,7 +1872,7 @@ export function collectExportData() {
 }
 
 // Save the current session to Firestore under
-// contractors/ruapehu_shearing/sessions/[stationName_date_teamLeader]
+// contractors/{contractorId}/sessions/[stationName_date_teamLeader]
 export async function saveSessionToFirestore(showStatus = false) {
     if (typeof firebase === 'undefined' ||
         !firebase.firestore ||
@@ -1916,15 +1916,21 @@ export async function saveSessionToFirestore(showStatus = false) {
 export async function listSessionsFromFirestore() {
     if (typeof firebase === 'undefined' ||
         !firebase.firestore ||
-        !firebase.auth ||
-        !firebase.auth().currentUser) {
+        !firebase.auth) {
+        return [];
+    }
+
+    const currentUser = firebase.auth().currentUser;
+    if (!currentUser) {
+        alert('You must be signed in to load sessions from the cloud.');
         return [];
     }
 
     try {
+        const contractorId = currentUser.uid;
         const snap = await firebase.firestore()
             .collection('contractors')
-            .doc('ruapehu_shearing')
+            .doc(contractorId)
             .collection('sessions')
             .get();
 
@@ -1946,14 +1952,21 @@ export async function listSessionsFromFirestore() {
 // Fetch a specific session document by ID
 export async function loadSessionFromFirestore(id) {
     if (!id || typeof firebase === 'undefined' ||
-        !firebase.firestore || !firebase.auth || !firebase.auth().currentUser) {
+        !firebase.firestore || !firebase.auth) {
+        return null;
+    }
+
+    const currentUser = firebase.auth().currentUser;
+    if (!currentUser) {
+        alert('You must be signed in to load sessions from the cloud.');
         return null;
     }
 
     try {
+        const contractorId = currentUser.uid;
         const docSnap = await firebase.firestore()
             .collection('contractors')
-            .doc('ruapehu_shearing')
+            .doc(contractorId)
             .collection('sessions')
             .doc(id)
             .get();


### PR DESCRIPTION
## Summary
- save sessions under per-user path in Firestore
- load session lists scoped to signed-in contractor
- alert when trying to load without signing in

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884e88fd0088321aa1052e1014b66ed