### PR TITLE
Add Firestore user verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ The first time you load the app while online, its files are cached by the servic
 
 There is no build step. All files live inside the `public/` folder, so just serve that directory as described above.
 
+## Firestore Structure
+
+Each contractor document has a `users` subcollection used to manage worker
+accounts. Documents in `contractors/{contractorId}/users` contain:
+
+- `email` – the worker's login email
+- `name` – their display name
+- `role` – permissions like `admin`, `shed_hand` or `presser`
+
+After sign‑in the app confirms the current email exists in that subcollection
+and signs out if it does not.
+
 ## PWA Features
 
 - **Installable**: Supported browsers will offer an install prompt.


### PR DESCRIPTION
## Summary
- describe Firestore users subcollection in README
- add `verifyContractorUser` helper in `tally.js`
- check users subcollection after sign-in

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688586896e8883218fadf3d1c2123dce