### PR TITLE
Add role-based redirect in login

### DIFF
--- a/public/login.html
+++ b/public/login.html
@@ -28,6 +28,7 @@
   </style>
   <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
   <script src="firebase-init.js"></script>
   <script src="login.js"></script>
 </head>

--- a/public/login.js
+++ b/public/login.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
-  
+
   const auth = firebase.auth();
+  const db = firebase.firestore ? firebase.firestore() : null;
 
   document.getElementById('loginForm').addEventListener('submit', async (e) => {
     e.preventDefault();
@@ -8,9 +9,24 @@ document.addEventListener('DOMContentLoaded', () => {
     const password = document.getElementById('password').value.trim();
 
     try {
-      await auth.signInWithEmailAndPassword(email, password);
+      const cred = await auth.signInWithEmailAndPassword(email, password);
       console.log("Login success");
-      window.location.href = 'tally.html';
+
+      if (db && cred.user) {
+        const docRef = db.collection('contractors').doc(cred.user.uid);
+        try {
+          const snap = await docRef.get();
+          const role = snap.exists ? snap.data().role : null;
+
+          if (role === 'contractor') {
+            window.location.href = 'dashboard.html';
+          } else if (role === 'staff') {
+            window.location.href = 'tally.html';
+          }
+        } catch (err) {
+          console.error('Failed to fetch user role:', err);
+        }
+      }
     } catch (err) {
       console.error("Login error:", err);
       alert("Login failed: " + err.message);


### PR DESCRIPTION
## Summary
- fetch contractor role from Firestore after a successful sign in
- redirect contractors to `dashboard.html` and staff to `tally.html`
- load Firestore SDK on login page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6885fac783708321b63c20100d35eed4