### PR TITLE
Convert createStaffUser to onCall

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1,26 +1,18 @@
 const functions = require('firebase-functions');
 const admin = require('firebase-admin');
-const cors = require('cors')({ origin: true });
-
 admin.initializeApp();
 
-exports.createStaffUser = functions.https.onRequest((req, res) => {
-  cors(req, res, async () => {
-    if (req.method !== 'POST') {
-      return res.status(405).send('Method Not Allowed');
-    }
+exports.createStaffUser = functions.https.onCall(async (data, context) => {
+  const { email, password } = data;
+  if (!email || !password) {
+    throw new functions.https.HttpsError('invalid-argument', 'Missing email or password');
+  }
 
-    const { email, password } = req.body;
-    if (!email || !password) {
-      return res.status(400).json({ error: 'Missing email or password' });
-    }
-
-    try {
-      const userRecord = await admin.auth().createUser({ email, password });
-      res.status(200).json({ uid: userRecord.uid });
-    } catch (err) {
-      console.error('Failed to create user', err);
-      res.status(500).json({ error: err.message });
-    }
-  });
+  try {
+    const userRecord = await admin.auth().createUser({ email, password });
+    return { uid: userRecord.uid };
+  } catch (err) {
+    console.error('Failed to create user', err);
+    throw new functions.https.HttpsError('internal', err.message);
+  }
 });


### PR DESCRIPTION
## Summary
- migrate the `createStaffUser` Cloud Function to `onCall`
- drop unused CORS wrapper
- return the created UID and throw `HttpsError` on errors

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688608082c948321a92e398a99f01224