### PR TITLE
Add log statement before createStaffUser

### DIFF
--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -105,6 +105,7 @@
         const tempPassword = generatePassword();
 
         try {
+          console.log("📤 Sending to function:", { email, tempPassword });
           const createStaffUser = firebase.functions().httpsCallable('createStaffUser');
           const result = await createStaffUser({ email, password: tempPassword });
           const uid = result.data.uid;


### PR DESCRIPTION
## Summary
- add logging before calling `createStaffUser` in `manage-staff.html`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6886102fbc688321b53c43f562d53f68