### PR TITLE
Move staff creation logic into module script

### DIFF
--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -63,6 +63,7 @@
 
   <script type="module">
     document.addEventListener('DOMContentLoaded', () => {
+      // Verify the user is logged in and is a contractor
       firebase.auth().onAuthStateChanged(async user => {
         if (!user) {
           window.location.replace('login.html');
@@ -79,58 +80,60 @@
         } catch (err) {
           console.error('Failed to verify role', err);
           window.location.replace('login.html');
+          return;
         }
+
+        // Listener for adding staff once the role is verified
+        const addBtn = document.getElementById('addStaffBtn');
+        addBtn.addEventListener('click', async () => {
+          const currentUser = firebase.auth().currentUser;
+          if (!currentUser) {
+            alert('Not authenticated');
+            return;
+          }
+
+          const contractorUid = currentUser.uid;
+          const email = document.getElementById('staffEmailInput').value.trim();
+          const role = document.getElementById('staffRoleSelect').value;
+          if (!email) {
+            alert('Please enter an email address');
+            return;
+          }
+
+          const generatePassword = (len = 10) => {
+            const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+            return Array.from({ length: len }, () => chars[Math.floor(Math.random() * chars.length)]).join('');
+          };
+
+          const tempPassword = generatePassword();
+          console.log('Creating staff user with', { email, password: tempPassword });
+
+          try {
+            const createStaffUser = firebase.functions().httpsCallable('createStaffUser');
+            const result = await createStaffUser({ email, password: tempPassword });
+            const uid = result.data.uid;
+
+            await firebase.firestore()
+              .collection('contractors')
+              .doc(contractorUid)
+              .collection('users')
+              .doc(uid)
+              .set({
+                email,
+                role,
+                createdAt: firebase.firestore.FieldValue.serverTimestamp()
+              });
+
+            console.log('Staff member added successfully');
+            alert('Staff member added!');
+          } catch (err) {
+            console.error('Failed to add staff member', err);
+            alert('Error creating staff member: ' + (err.message || err));
+          }
+        });
       });
 
     });
   </script>
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  const addBtn = document.getElementById('addStaffBtn');
-  addBtn.addEventListener('click', async function() {
-    const currentUser = firebase.auth().currentUser;
-    if (!currentUser) {
-      alert('Not authenticated');
-      return;
-    }
-
-    const contractorUid = currentUser.uid;
-    const email = document.getElementById('staffEmailInput').value.trim();
-    const role = document.getElementById('staffRoleSelect').value;
-    if (!email) {
-      alert('Please enter an email address');
-      return;
-    }
-
-    const generatePassword = (len = 10) => {
-      const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-      return Array.from({ length: len }, () => chars[Math.floor(Math.random() * chars.length)]).join('');
-    };
-    const tempPassword = generatePassword();
-
-    try {
-      const createStaffUser = firebase.functions().httpsCallable('createStaffUser');
-      const result = await createStaffUser({ email, password: tempPassword });
-      const uid = result.data.uid;
-
-      await firebase.firestore()
-        .collection('contractors')
-        .doc(contractorUid)
-        .collection('users')
-        .doc(uid)
-        .set({
-          email,
-          role,
-          createdAt: firebase.firestore.FieldValue.serverTimestamp()
-        });
-
-      alert('Staff member added!');
-    } catch (err) {
-      console.error('Failed to add staff member', err);
-      alert('Error creating staff member: ' + (err.message || err));
-    }
-  });
-});
-</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- refactor staff creation so logic resides inside module script
- ensure temp password generation and logging of credentials
- remove non-module script tag

## Testing
- `npm test` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68861dc4793c83219edac7521e7daa1d