### PR TITLE
Fix staff management to use Firebase modular APIs

### DIFF
--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -43,7 +43,6 @@
       max-width: 400px;
     }
   </style>
-  <script src="firebase-init.js"></script>
 </head>
 <body>
   <h2>Manage Staff</h2>
@@ -119,7 +118,7 @@
           };
 
           const tempPassword = generatePassword();
-          console.log('Creating staff user with', { email, password: tempPassword });
+          console.log('📤 Creating staff user with', { email, password: tempPassword });
 
           try {
             const createStaffUser = httpsCallable(functions, 'createStaffUser');


### PR DESCRIPTION
## Summary
- use modern Firebase modules in `manage-staff.html`
- log credentials when creating staff users

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688621fa6e2c83218c64f5c0d904d50d