### PR TITLE
Use httpsCallable correctly for createStaffUser

### DIFF
--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -73,7 +73,6 @@
     const app = initializeApp(firebaseConfig);
     const auth = getAuth(app);
     const db = getFirestore(app);
-    const functions = getFunctions(app);
 
     document.addEventListener('DOMContentLoaded', () => {
       onAuthStateChanged(auth, async user => {
@@ -117,12 +116,12 @@
             return Array.from({ length: len }, () => chars[Math.floor(Math.random() * chars.length)]).join('');
           };
 
-          const tempPassword = generatePassword();
-          console.log('📤 Creating staff user with', { email, password: tempPassword });
+          const password = generatePassword();
+          console.log('📤 Creating staff user with', { email, password });
 
           try {
-            const createStaffUser = httpsCallable(functions, 'createStaffUser');
-            const result = await createStaffUser({ email, password: tempPassword });
+            const createStaffUser = httpsCallable(getFunctions(), 'createStaffUser');
+            const result = await createStaffUser({ email, password });
             const uid = result.data.uid;
 
             await setDoc(doc(collection(doc(collection(db, 'contractors'), contractorUid), 'users'), uid), {


### PR DESCRIPTION
## Summary
- update staff creation logic to call `httpsCallable(getFunctions(), 'createStaffUser')`
- ensure password value is passed directly in the payload

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688623b656b88321914f802e983cc284