### PR TITLE
Fix Cloud Function payload

### DIFF
--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -121,7 +121,7 @@
 
           try {
             const createStaffUser = httpsCallable(getFunctions(), 'createStaffUser');
-            const result = await createStaffUser({ email, password });
+            const result = await createStaffUser({ data: { email, password } });
             const uid = result.data.uid;
 
             await setDoc(doc(collection(doc(collection(db, 'contractors'), contractorUid), 'users'), uid), {


### PR DESCRIPTION
## Summary
- adjust staff creation code to wrap payload with `data` when calling the Cloud Function

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6886267e878c8321a9ab231d57e6ebc0