### PR TITLE
Fix manage staff auth

### DIFF
--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -62,7 +62,7 @@
     import { getFunctions, httpsCallable } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-functions.js';
 
     const firebaseConfig = {
-      apiKey: 'AIzaSyCuQh49AgKbrMvrxcuwsR8Svy86aP3Fg2Q',
+      apiKey: 'AIzaSyD529f2jn9mb8OAip4x6l3IQb7KOaPNxaM',
       authDomain: 'sheariq-tally-app.firebaseapp.com',
       projectId: 'sheariq-tally-app',
       storageBucket: 'sheariq-tally-app.firebasestorage.app',


### PR DESCRIPTION
## Summary
- use the same Firebase project config in `manage-staff.html`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6886cd23e4ec8321bbbfb323ef46998b