### PR TITLE
Use httpsCallable for createStaffUser

### DIFF
--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -73,6 +73,7 @@
     const app = initializeApp(firebaseConfig);
     const auth = getAuth(app);
     const db = getFirestore(app);
+    const functions = getFunctions(app);
 
     document.addEventListener('DOMContentLoaded', () => {
       onAuthStateChanged(auth, async user => {
@@ -120,7 +121,7 @@
           console.log('📤 Creating staff user with', { email, password });
 
           try {
-            const createStaffUser = httpsCallable(getFunctions(app), 'createStaffUser');
+            const createStaffUser = httpsCallable(functions, 'createStaffUser');
             const result = await createStaffUser({ email, password });
             const uid = result.data.uid;
             console.log('Created staff user UID:', uid);


### PR DESCRIPTION
## Summary
- call `getFunctions` once and pass the instance to `httpsCallable`
- invoke the `createStaffUser` function with the generated email and password

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_6886f9aa4308832189f3e437b38451c0