### PR TITLE
Add sendStaffCredentials cloud function

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1,6 +1,7 @@
 const functions = require('firebase-functions');
 const { onCall } = require('firebase-functions/v2/https');
 const admin = require('firebase-admin');
+const nodemailer = require('nodemailer');
 admin.initializeApp();
 
 exports.createStaffUser = onCall(async (request) => {
@@ -13,4 +14,31 @@ exports.createStaffUser = onCall(async (request) => {
 
   const userRecord = await admin.auth().createUser({ email, password });
   return { uid: userRecord.uid };
+});
+
+exports.sendStaffCredentials = onCall(async (request) => {
+  const { staffName, staffEmail, password, contractorEmail } = request.data;
+
+  try {
+    const transporter = nodemailer.createTransport({
+      service: 'gmail',
+      auth: {
+        user: process.env.GMAIL_USER,
+        pass: process.env.GMAIL_PASS,
+      },
+    });
+
+    const mailOptions = {
+      from: process.env.GMAIL_USER,
+      to: contractorEmail,
+      subject: 'New Staff Login Created',
+      text: `Kia ora,\n\nYou've created a new SHE\u0394R iQ staff login.\n\nName: ${staffName}\nEmail: ${staffEmail}\nTemporary Password: ${password}\n\nPlease forward these details to your staff member. They will be prompted to change their password on first login.\n\nNg\u0101 mihi,\nThe SHE\u0394R iQ Team`,
+    };
+
+    await transporter.sendMail(mailOptions);
+    return { success: true };
+  } catch (error) {
+    console.error('Error sending staff credentials', error);
+    return { success: false, error: error.message };
+  }
 });

--- a/functions/package.json
+++ b/functions/package.json
@@ -14,7 +14,8 @@
   "main": "index.js",
   "dependencies": {
     "firebase-admin": "^12.6.0",
-    "firebase-functions": "^6.0.1"
+    "firebase-functions": "^6.0.1",
+    "nodemailer": "^6.9.1"
   },
   "devDependencies": {
     "firebase-functions-test": "^3.1.0"


### PR DESCRIPTION
## Summary
- add Nodemailer dependency for sending emails
- implement `sendStaffCredentials` onCall function

## Testing
- `npm test` *(fails: Missing script)*
- `npm install` *(fails: 403 Forbidden due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6887174f6cdc8321954b946790103bf2