### PR TITLE
Improve logging for staff credentials function

### DIFF
--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -140,17 +140,21 @@
               createdAt: serverTimestamp()
             });
 
+            console.log("✅ Reached sendStaffCredentials function");
+            console.log("📧 Contractor email:", auth.currentUser?.email);
+            console.log("staffName:", name, "staffEmail:", email, "password:", password);
+
             try {
               const sendStaffCredentials = httpsCallable(functions, 'sendStaffCredentials');
-              await sendStaffCredentials({
+              const response = await sendStaffCredentials({
                 staffName: name,
                 staffEmail: email,
                 password,
                 contractorEmail: auth.currentUser.email
               });
-              console.log('Staff credentials email sent successfully');
+              console.log("📨 Staff credentials email sent successfully:", response.data);
             } catch (error) {
-              console.error('Failed to send staff credentials email:', error);
+              console.error("❌ Email function failed:", error.message || error);
             }
 
             console.log('Staff member added successfully');


### PR DESCRIPTION
## Summary
- debug sendStaffCredentials call in manage-staff page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688735f8ae7483218e6a3ae944b37843