### PR TITLE
Add staff name input requirement

### DIFF
--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -47,7 +47,8 @@
 <body>
   <h2>Manage Staff</h2>
   <form id="staffForm">
-    <input type="text" id="staffNameInput" placeholder="Name" required>
+    <label for="staff-name">Staff Name</label>
+    <input type="text" id="staff-name" placeholder="Enter staff member’s name" required>
     <input type="email" id="staffEmailInput" placeholder="Email" required>
     <select id="staffRoleSelect">
       <option value="staff">staff</option>
@@ -106,10 +107,10 @@
           }
 
           const contractorUid = currentUser.uid;
-          const name = document.getElementById('staffNameInput').value.trim();
+          const staffName = document.getElementById('staff-name').value.trim();
           const email = document.getElementById('staffEmailInput').value.trim();
           const role = document.getElementById('staffRoleSelect').value;
-          if (!name) {
+          if (!staffName) {
             alert('Please enter a name');
             return;
           }
@@ -134,7 +135,7 @@
 
             const staffRef = doc(db, 'contractors', contractorUid, 'staff', uid);
             await setDoc(staffRef, {
-              name,
+              name: staffName,
               email,
               role,
               createdAt: serverTimestamp()
@@ -143,7 +144,7 @@
             try {
               const sendStaffCredentials = httpsCallable(functions, 'sendStaffCredentials');
               await sendStaffCredentials({
-                staffName: name,
+                staffName,
                 staffEmail: email,
                 password,
                 contractorEmail: auth.currentUser.email


### PR DESCRIPTION
## Summary
- add a labeled staff name field to manage-staff.html
- capture staffName in the script and pass it to Firestore and sendStaffCredentials

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688738585dfc8321a6b2b68128b289c6