### PR TITLE
Add role-based login redirects

### DIFF
--- a/public/login.js
+++ b/public/login.js
@@ -9,34 +9,42 @@ document.addEventListener('DOMContentLoaded', () => {
     const password = document.getElementById('password').value.trim();
 
     try {
+      // Sign in with Firebase Auth
       const cred = await auth.signInWithEmailAndPassword(email, password);
-      console.log("Login success");
+      console.log('Login success');
 
-      const contractorId = "USc1VVmUDHQiWW3yvvcaHbyJVFX2"; // <- Your contractor UID
-      const staffRef = db.collection('contractors')
-                         .doc(contractorId)
-                         .collection('staff');
+      // Get UID and email of the authenticated user
+      const { uid, email: userEmail } = cred.user;
 
-      const query = await staffRef.where("email", "==", email).limit(1).get();
+      // Check if the user is a contractor by looking for a document
+      // at contractors/{UID}
+      const contractorDoc = await db.collection('contractors').doc(uid).get();
+      if (contractorDoc.exists) {
+        window.location.href = 'dashboard.html';
+        return;
+      }
+
+      // Not a contractor - check staff records for the predefined contractorId
+      const contractorId = 'USc1VVmUDHQiWW3yvvcaHbyJVFX2';
+      const staffRef = db
+        .collection('contractors')
+        .doc(contractorId)
+        .collection('staff');
+
+      const query = await staffRef.where('email', '==', userEmail).limit(1).get();
 
       if (!query.empty) {
-        const userDoc = query.docs[0].data();
-        const role = userDoc.role;
-
-        if (role === "contractor") {
-          window.location.href = 'dashboard.html';
-        } else if (role === "staff") {
-          window.location.href = 'tally.html';
-        } else {
-          alert("Unauthorized role: " + role);
-        }
+        // Staff member found
+        window.location.href = 'tally.html';
       } else {
-        alert("No role found in staff records for this user.");
+        // No matching staff record
+        alert('No role found in staff records for this user.');
+        await auth.signOut();
       }
 
     } catch (err) {
-      console.error("Login error:", err);
-      alert("Login failed: " + err.message);
+      console.error('Login error:', err);
+      alert('Login failed: ' + err.message);
     }
   });
 });


### PR DESCRIPTION
## Summary
- update login form handler to determine user role via Firestore

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688838f775708321b800670560e330f9