### PR TITLE
Fix login redirects and clear caches on signout

### DIFF
--- a/public/auth.js
+++ b/public/auth.js
@@ -6,7 +6,10 @@ firebase.auth().onAuthStateChanged(user => {
 
 export function logout() {
   firebase.auth().signOut().then(() => {
-    window.location.href = 'login.html';
+    // Clear any cached session data after sign out
+    localStorage.clear();
+    sessionStorage.clear();
+    window.location.replace('login.html');
   });
 }
 

--- a/public/login.js
+++ b/public/login.js
@@ -20,7 +20,8 @@ document.addEventListener('DOMContentLoaded', () => {
       // at contractors/{UID}
       const contractorDoc = await db.collection('contractors').doc(uid).get();
       if (contractorDoc.exists) {
-        window.location.href = 'dashboard.html';
+        // Use replace to ensure a hard reload after login
+        window.location.replace('dashboard.html');
         return;
       }
 
@@ -35,11 +36,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
       if (!query.empty) {
         // Staff member found
-        window.location.href = 'tally.html';
+        window.location.replace('tally.html');
       } else {
         // No matching staff record
         alert('No role found in staff records for this user.');
         await auth.signOut();
+        // Clear any cached session data after sign out
+        localStorage.clear();
+        sessionStorage.clear();
       }
 
     } catch (err) {


### PR DESCRIPTION
## Summary
- force a reload when navigating away from login page
- make logout clear browser caches

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6888448ee8ac8321b87eeee726c54c53