### PR TITLE
Fix tally clean up logic

### DIFF
--- a/public/tally.js
+++ b/public/tally.js
@@ -1241,8 +1241,13 @@ let saveCallback = null;
 let manualSave = false;
 
 function performSave(saveLocal, saveCloud, manual) {
+    const finishTime = document.getElementById('finishTime')?.value;
+    const sessionHasEnded = finishTime && finishTime.trim() !== '';
+
     if ((isSetupComplete && hasUserStartedEnteringData) || manual) {
-        cleanUpEmptyRowsAndColumns(manual);
+        if (sessionHasEnded || manual) {
+            cleanUpEmptyRowsAndColumns(manual);
+        }
     }
     clearHighlights();
     const issues = [];


### PR DESCRIPTION
## Summary
- avoid cleaning up rows/cols on autosave until Finish Time is entered

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68885b3c541c832197bc5c36c3326f1a