### PR TITLE
Fix startup race for contractor id

### DIFF
--- a/public/tally.js
+++ b/public/tally.js
@@ -2443,6 +2443,17 @@ const body = document.getElementById('tallyBody');
 window.rebuildRowsFromSession = rebuildRowsFromSession;
 window.resetTallySheet = resetTallySheet;
 
+function setup() {
+  verifyContractorUser();
+}
+
 firebase.auth().onAuthStateChanged(user => {
-    if (user) verifyContractorUser();
+  if (!user) return;
+  const timer = setInterval(() => {
+    const contractorId = localStorage.getItem('contractor_id');
+    if (contractorId) {
+      clearInterval(timer);
+      setup();
+    }
+  }, 100);
 });


### PR DESCRIPTION
## Summary
- avoid running contractor auth until `contractor_id` exists

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68888deb82648321a2deb67d55618226