### PR TITLE
Fix asynchronous user setup for tally

### DIFF
--- a/public/tally.js
+++ b/public/tally.js
@@ -2443,8 +2443,8 @@ const body = document.getElementById('tallyBody');
 window.rebuildRowsFromSession = rebuildRowsFromSession;
 window.resetTallySheet = resetTallySheet;
 
-function setup() {
-  verifyContractorUser();
+async function setup() {
+  await verifyContractorUser();
 }
 
 firebase.auth().onAuthStateChanged(user => {


### PR DESCRIPTION
## Summary
- ensure tally's `setup` waits for user verification

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688890e860b083218ae25ed5c5a097f0