### PR TITLE
Delay app setup until auth is restored

### DIFF
--- a/public/tally.js
+++ b/public/tally.js
@@ -2448,12 +2448,7 @@ async function setup() {
 }
 
 firebase.auth().onAuthStateChanged(user => {
-  if (!user) return;
-  const timer = setInterval(() => {
-    const contractorId = localStorage.getItem('contractor_id');
-    if (contractorId) {
-      clearInterval(timer);
-      setup();
-    }
-  }, 100);
+  if (user) {
+    setup();
+  }
 });


### PR DESCRIPTION
## Summary
- call `setup()` only when Firebase auth state has a user

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688899b4aa2c832189e9b9bdb0c33e31