### PR TITLE
Fix staff contractorId lookup

### DIFF
--- a/public/auth-check.js
+++ b/public/auth-check.js
@@ -15,8 +15,8 @@ firebase.auth().onAuthStateChanged(async function (user) {
         return;
       } else if (role === "staff") {
         console.log("[auth-check] Found matching staff");
-        const contractorId = userData.contractorId;
-        console.log("[auth-check] Retrieved contractorId:", contractorId);
+        const contractorId = docSnap.data().contractorId;
+        console.log('[auth-check] contractorId from staff profile:', contractorId);
         if (contractorId) {
           localStorage.setItem("contractor_id", contractorId);
           console.log(`[auth-check] localStorage.setItem('contractor_id', '${contractorId}') called`);


### PR DESCRIPTION
## Summary
- fix staff login branch to use `contractorId` field
- log contractorId from staff profile

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6888affb2c1083219e4aa3805d867d0f