### PR TITLE
Disable login redirects for debugging

### DIFF
--- a/public/login.js
+++ b/public/login.js
@@ -21,7 +21,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const contractorDoc = await db.collection('contractors').doc(uid).get();
       if (contractorDoc.exists) {
         // Use replace to ensure a hard reload after login
-        window.location.replace('dashboard.html');
+        console.log('[login] ✅ Contractor document found, would redirect to dashboard.html');
         return;
       }
 
@@ -35,8 +35,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const query = await staffRef.where('email', '==', userEmail).limit(1).get();
 
       if (!query.empty) {
-        // Staff member found
-        window.location.replace('tally.html');
+        console.log('[login] ✅ Staff member found, would redirect to tally.html');
       } else {
         // No matching staff record
         alert('No role found in staff records for this user.');


### PR DESCRIPTION
## Summary
- log when login is successful but hold off on redirecting

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6888bc044f488321acceacd288b8ac66