### PR TITLE
Use contractor ID from localStorage

### DIFF
--- a/public/tally.js
+++ b/public/tally.js
@@ -2007,14 +2007,13 @@ export async function listSessionsFromFirestore() {
         return [];
     }
 
-    const currentUser = firebase.auth().currentUser;
-    if (!currentUser) {
-        alert('You must be signed in to load sessions from the cloud.');
+    const contractorId = localStorage.getItem('contractor_id');
+    if (!contractorId) {
+        alert('No contractor ID found');
         return [];
     }
 
     try {
-        const contractorId = currentUser.uid;
         const snap = await firebase.firestore()
             .collection('contractors')
             .doc(contractorId)
@@ -2043,14 +2042,13 @@ export async function loadSessionFromFirestore(id) {
         return null;
     }
 
-    const currentUser = firebase.auth().currentUser;
-    if (!currentUser) {
-        alert('You must be signed in to load sessions from the cloud.');
+    const contractorId = localStorage.getItem('contractor_id');
+    if (!contractorId) {
+        alert('No contractor ID found');
         return null;
     }
 
     try {
-        const contractorId = currentUser.uid;
         const docSnap = await firebase.firestore()
             .collection('contractors')
             .doc(contractorId)


### PR DESCRIPTION
## Summary
- rely on contractor ID stored in localStorage when listing and loading sessions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68894fcb95bc83219b361c326888a8d6