### PR TITLE
Fix duplicate sessions listing

### DIFF
--- a/public/tally.js
+++ b/public/tally.js
@@ -2020,7 +2020,7 @@ export async function listSessionsFromFirestore() {
             .collection('sessions')
             .get();
 
-        return snap.docs.map(doc => {
+        const sessions = snap.docs.map(doc => {
             const d = doc.data() || {};
             return {
                 id: doc.id,
@@ -2029,6 +2029,15 @@ export async function listSessionsFromFirestore() {
                 teamLeader: d.teamLeader
             };
         });
+
+        const seen = new Set();
+        const uniqueSessions = sessions.filter(session => {
+            if (seen.has(session.id)) return false;
+            seen.add(session.id);
+            return true;
+        });
+
+        return uniqueSessions;
     } catch (err) {
         console.error('❌ Failed to list sessions from Firestore:', err);
         return [];


### PR DESCRIPTION
## Summary
- ensure unique Firestore sessions are listed for the cloud loader

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68896f00b42c83218084715bece55d65