### PR TITLE
Fix overwriting Firestore sessions when loading data

### DIFF
--- a/public/tally.js
+++ b/public/tally.js
@@ -2064,7 +2064,11 @@ export async function loadSessionFromFirestore(id) {
             .collection('sessions')
             .doc(id)
             .get();
-        return docSnap.exists ? docSnap.data() : null;
+        if (docSnap.exists) {
+            firestoreSessionId = id; // ensure subsequent saves update this doc
+            return docSnap.data();
+        }
+        return null;
     } catch (err) {
         console.error('❌ Failed to load session from Firestore:', err);
         return null;


### PR DESCRIPTION
## Summary
- retain loaded session ID so autosave and manual saves update the correct Firestore document

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68899d540924832195e39df5446755b7