### PR TITLE
Ensure firestore session ID created on unlock

### DIFF
--- a/public/tally.js
+++ b/public/tally.js
@@ -492,6 +492,19 @@ function unlockSession() {
     sessionLocked = false;
     document.querySelectorAll('#tallySheetView input').forEach(inp => inp.readOnly = false);
     document.querySelectorAll('#tallySheetView select').forEach(sel => sel.disabled = false);
+
+    // Ensure a Firestore document ID exists when unlocking a view-only session
+    if (!firestoreSessionId &&
+        document.getElementById('stationName') &&
+        document.getElementById('date') &&
+        document.getElementById('teamLeader')) {
+        const station = document.getElementById('stationName').value.trim().replace(/\s+/g, '_');
+        const date = document.getElementById('date').value;
+        const leader = document.getElementById('teamLeader').value.trim().replace(/\s+/g, '_');
+        if (station && date && leader) {
+            firestoreSessionId = `${station}_${date}_${leader}`;
+        }
+    }
 }
 
 function promptForPinUnlock() {


### PR DESCRIPTION
## Summary
- generate Firestore document ID if missing when unlocking a view-only session

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a0a4177788321a28e6a324b1b8f90