### PR TITLE
Return full objects for cloud sessions

### DIFF
--- a/public/tally.js
+++ b/public/tally.js
@@ -2052,12 +2052,7 @@ export async function listSessionsFromFirestore() {
 
         const sessions = snap.docs.map(doc => {
             const d = doc.data() || {};
-            return {
-                id: doc.id,
-                stationName: d.stationName,
-                date: d.date,
-                teamLeader: d.teamLeader
-            };
+            return { id: doc.id, ...d };
         });
 
         const seen = new Set();


### PR DESCRIPTION
## Summary
- return all fields when listing cloud sessions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a1cfb61f08321a9a64873ec4d3adb