### PR TITLE
Add persistent login option

### DIFF
--- a/public/login.html
+++ b/public/login.html
@@ -16,8 +16,14 @@
       color: #fff;
     }
     #loginForm { background: #000; padding: 20px; border-radius: 4px; width: 300px; }
-    #loginForm input { width: 100%; padding: 8px; margin: 6px 0; }
+    #loginForm input:not([type="checkbox"]) { width: 100%; padding: 8px; margin: 6px 0; }
     #loginForm button[type="submit"] { width: 100%; padding: 10px; }
+    #rememberMeLabel {
+      display: flex;
+      align-items: center;
+      margin: 6px 0;
+    }
+    #rememberMeLabel input { width: auto; margin-right: 6px; }
     .password-container { position: relative; }
     .password-container input { padding-right: 50px; }
     .password-container button {
@@ -55,6 +61,10 @@
       <input type="password" id="password" placeholder="Password" required>
       <button type="button" id="togglePassword">Show</button>
     </div>
+    <label id="rememberMeLabel">
+      <input type="checkbox" id="rememberMe">
+      Remember Me
+    </label>
     <button type="submit">Login</button>
   </form>
 </body>

--- a/public/login.js
+++ b/public/login.js
@@ -17,8 +17,13 @@ document.addEventListener('DOMContentLoaded', () => {
     e.preventDefault();
     const email = document.getElementById('email').value.trim();
     const password = document.getElementById('password').value.trim();
+    const remember = document.getElementById('rememberMe').checked;
 
     try {
+      const persistence = remember
+        ? firebase.auth.Auth.Persistence.LOCAL
+        : firebase.auth.Auth.Persistence.SESSION;
+      await auth.setPersistence(persistence);
       // Sign in with Firebase Auth
       const cred = await auth.signInWithEmailAndPassword(email, password);
       console.log('Login success');


### PR DESCRIPTION
## Summary
- add Remember Me checkbox on login page
- set Firebase Auth persistence based on whether Remember Me is checked

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a9eae74288321920c5f7ed1281f13