### PR TITLE
Improve login error messaging

### DIFF
--- a/public/login.js
+++ b/public/login.js
@@ -97,6 +97,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     } catch (err) {
       console.error('Login error:', err);
+      console.log('Firebase Auth error code:', err.code);
       const errorDiv = document.getElementById('login-error');
       let message = '';
 
@@ -106,6 +107,7 @@ document.addEventListener('DOMContentLoaded', () => {
           break;
         case 'auth/user-not-found':
         case 'auth/wrong-password':
+        case 'auth/invalid-login-credentials':
           message = 'Incorrect email or password';
           break;
         case 'auth/too-many-requests':


### PR DESCRIPTION
## Summary
- add console log for Firebase Auth error codes
- handle `auth/invalid-login-credentials` in login error switch

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688b332e389c8321a6e67662a9080135