### PR TITLE
Unify spinner overlay across pages

### DIFF
--- a/public/auth-check.html
+++ b/public/auth-check.html
@@ -4,42 +4,17 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Checking Authentication...</title>
+  <link rel="stylesheet" href="styles.css">
   <style>
-  body {
+    body {
       margin: 0;
       height: 100vh;
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
       background: #000;
       color: #fff;
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
       pointer-events: none;
       user-select: none;
     }
-    #logo {
-      width: 200px;
-      max-width: 80%;
-      opacity: 0;
-      animation: fadeIn 2s forwards, pulse 6s infinite 2s;
-    }
-    #message { margin-top: 20px; font-size: 1.2em; }
-    .loader {
-      margin-top: 20px;
-      width: 40px;
-      height: 40px;
-      border-radius: 50%;
-      border: 4px solid rgba(255, 215, 0, 0.3);
-      border-top-color: #ffd700;
-      animation: spin 1s linear infinite;
-    }
-    @keyframes spin { to { transform: rotate(360deg); } }
-    @keyframes fadeIn { to { opacity: 1; } }
-    @keyframes pulse {
-      0%, 100% { transform: scale(1); }
-      50% { transform: scale(1.05); }
-    }  
   </style>
   <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
@@ -47,9 +22,10 @@
   <script src="firebase-init.js"></script>
 </head>
 <body>
-<img id="logo" src="logo.png" alt="SHEΔR iQ logo">
-  <div id="message"> Checking login… Please wait.</div>
-  <div class="loader"></div>
+<div id="loading-overlay" class="show">
+  <img src="logo.png" class="spinner-logo" alt="Loading">
+  <div>Checking login… Please wait.</div>
+</div>
 
   <script src="auth-check.js"></script>
 </body>

--- a/public/login.html
+++ b/public/login.html
@@ -74,7 +74,7 @@
     <button type="submit">Login</button>
     <div id="login-error"></div>
   </form>
-  <div id="login-loading-overlay">
+  <div id="loading-overlay">
     <img src="logo.png" class="spinner-logo" alt="Loading">
     <div>Starting your shed session…</div>
   </div>

--- a/public/login.js
+++ b/public/login.js
@@ -34,7 +34,7 @@ document.addEventListener('DOMContentLoaded', () => {
   loginForm.addEventListener('submit', async (e) => {
     e.preventDefault();
 
-    const loadingOverlay = document.getElementById('login-loading-overlay');
+    const loadingOverlay = document.getElementById('loading-overlay');
     const submitButton = loginForm.querySelector('button[type="submit"]');
     if (loadingOverlay) {
       loadingOverlay.style.display = 'flex';

--- a/public/styles.css
+++ b/public/styles.css
@@ -383,8 +383,8 @@ button {
     font-weight: 500;
 }
 
-/* Login loading overlay */
-#login-loading-overlay {
+/* Loading overlay */
+#loading-overlay {
   position: fixed;
   top: 0;
   left: 0;
@@ -402,14 +402,14 @@ button {
   transition: opacity 0.3s ease;
 }
 
-#login-loading-overlay.show {
+#loading-overlay.show {
   opacity: 1;
 }
 
 .spinner-logo {
-  width: 50px;
-  height: 50px;
-  animation: spinner-rotate 4s linear infinite;
+  width: 70px;
+  height: 70px;
+  animation: spinner-rotate 6s linear infinite;
   margin-bottom: 10px;
   border-radius: 50%;
   object-fit: cover;


### PR DESCRIPTION
## Summary
- replace login-loading overlay with generic `#loading-overlay`
- switch auth-check page to use branded spinner overlay
- update spinner CSS to 70x70px with slower spin

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688b4322e72c832180c1fadb8dc9174a