### PR TITLE
Add shared loading overlay to authenticated pages

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -58,6 +58,8 @@
 
   <script type="module">
     document.addEventListener('DOMContentLoaded', () => {
+      const overlay = document.getElementById('loading-overlay');
+      if (overlay) overlay.style.display = 'flex';
       firebase.auth().onAuthStateChanged(async user => {
         if (!user) {
           window.location.replace('login.html');
@@ -76,6 +78,8 @@
         } catch (err) {
           console.error('Failed to verify role', err);
           window.location.replace('login.html');
+        } finally {
+          if (overlay) overlay.style.display = 'none';
         }
       });
     });
@@ -116,5 +120,9 @@
       window.location.href = 'settings.html';
     });
   </script>
+  <div id="loading-overlay">
+    <img src="logo.png" class="spinner-logo" alt="Loading">
+    <div>Authenticating… Please wait</div>
+  </div>
 </body>
 </html>

--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -78,6 +78,8 @@
     const functions = getFunctions(app);
 
     document.addEventListener('DOMContentLoaded', () => {
+      const overlay = document.getElementById('loading-overlay');
+      if (overlay) overlay.style.display = 'flex';
       onAuthStateChanged(auth, async user => {
         if (!user) {
           window.location.replace('login.html');
@@ -97,7 +99,8 @@
           window.location.replace('login.html');
           return;
         }
-
+        if (overlay) overlay.style.display = 'none';
+        
         const addBtn = document.getElementById('addStaffBtn');
         addBtn.addEventListener('click', async () => {
           const currentUser = auth.currentUser;
@@ -166,8 +169,12 @@
             alert('Error creating staff member: ' + (err.message || err));
           }
         });
-      });
     });
+  });
   </script>
+  <div id="loading-overlay">
+    <img src="logo.png" class="spinner-logo" alt="Loading">
+    <div>Authenticating… Please wait</div>
+  </div>
 </body>
 </html>

--- a/public/tally.html
+++ b/public/tally.html
@@ -448,6 +448,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
 <div id="autosaveStatus" style="display:none; position:fixed; bottom:10px; right:10px; background:#222; color:#fff; padding:4px 8px; border-radius:4px; font-size:14px;"></div>
 <div id="autosaveInfo" style="display:none; position:fixed; bottom:10px; left:10px; color:#888; font-size:12px;"></div>
+<div id="loading-overlay">
+  <img src="logo.png" class="spinner-logo" alt="Loading">
+  <div>Authenticating… Please wait</div>
+</div>
 
 </body>
 </html>

--- a/public/tally.js
+++ b/public/tally.js
@@ -2521,7 +2521,13 @@ window.resetTallySheet = resetTallySheet;
 window.resetForNewDay = resetForNewDay;
 
 async function setup() {
-  await verifyContractorUser();
+  const overlay = document.getElementById('loading-overlay');
+  if (overlay) overlay.style.display = 'flex';
+  try {
+    await verifyContractorUser();
+  } finally {
+    if (overlay) overlay.style.display = 'none';
+  }
 }
 
 firebase.auth().onAuthStateChanged(user => {


### PR DESCRIPTION
## Summary
- show a loading overlay while auth/session checks run
- reuse same overlay HTML in tally, dashboard and manage-staff pages
- display spinner during user verification in corresponding scripts

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688b45804ea483218b2d9a6c32225378