### PR TITLE
Restore gold CSS spinner

### DIFF
--- a/public/auth-check.html
+++ b/public/auth-check.html
@@ -23,7 +23,7 @@
 </head>
 <body>
 <div id="loading-overlay" class="show">
-  <img src="logo.png" class="spinner-logo" alt="Loading">
+  <div class="circle-spinner"></div>
   <div>Checking login… Please wait.</div>
 </div>
 

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -121,7 +121,7 @@
     });
   </script>
   <div id="loading-overlay">
-    <img src="logo.png" class="spinner-logo" alt="Loading">
+    <div class="circle-spinner"></div>
     <div>Authenticating… Please wait</div>
   </div>
 </body>

--- a/public/login.html
+++ b/public/login.html
@@ -75,7 +75,7 @@
     <div id="login-error"></div>
   </form>
   <div id="loading-overlay">
-    <img src="logo.png" class="spinner-logo" alt="Loading">
+    <div class="circle-spinner"></div>
     <div>Starting your shed session…</div>
   </div>
 </body>

--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -173,7 +173,7 @@
   });
   </script>
   <div id="loading-overlay">
-    <img src="logo.png" class="spinner-logo" alt="Loading">
+    <div class="circle-spinner"></div>
     <div>Authenticating… Please wait</div>
   </div>
 </body>

--- a/public/styles.css
+++ b/public/styles.css
@@ -406,13 +406,15 @@ button {
   opacity: 1;
 }
 
-.spinner-logo {
-  width: 70px;
-  height: 70px;
-  animation: spinner-rotate 6s linear infinite;
-  margin-bottom: 10px;
+/* Gold circular spinner */
+.circle-spinner {
+  width: 80px;
+  height: 80px;
+  border: 8px solid gold;
+  border-top-color: transparent;
   border-radius: 50%;
-  object-fit: cover;
+  animation: spinner-rotate 1s linear infinite;
+  margin-bottom: 10px;
 }
 
 @keyframes spinner-rotate {

--- a/public/tally.html
+++ b/public/tally.html
@@ -449,7 +449,7 @@ document.addEventListener('DOMContentLoaded', () => {
 <div id="autosaveStatus" style="display:none; position:fixed; bottom:10px; right:10px; background:#222; color:#fff; padding:4px 8px; border-radius:4px; font-size:14px;"></div>
 <div id="autosaveInfo" style="display:none; position:fixed; bottom:10px; left:10px; color:#888; font-size:12px;"></div>
 <div id="loading-overlay">
-  <img src="logo.png" class="spinner-logo" alt="Loading">
+  <div class="circle-spinner"></div>
   <div>Authenticating… Please wait</div>
 </div>
 


### PR DESCRIPTION
## Summary
- reintroduce CSS animated gold spinner
- swap out image-based spinners on login, auth-check, manage-staff, tally and dashboard pages

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688c1dd424388321bcd6bf2f3ad47614