### PR TITLE
Add loading spinner support on logout

### DIFF
--- a/public/auth.js
+++ b/public/auth.js
@@ -11,7 +11,14 @@ export function logout() {
   if (!confirmed) {
     return;
   }
+  const overlay = document.getElementById('loading-overlay');
+  if (overlay) {
+    overlay.style.display = 'flex';
+  }
   firebase.auth().signOut().then(() => {
+    if (overlay) {
+      overlay.style.display = 'none';
+    }
     // Clear any cached session data after sign out
     localStorage.clear();
     sessionStorage.clear();


### PR DESCRIPTION
## Summary
- show/hide spinner in `logout()` if `#loading-overlay` exists

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688c62fea3d48321b9a52acd4ba7fe94