### PR TITLE
Use Secret Manager comment for Gmail credentials

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -51,3 +51,4 @@ console.log("DEBUG - GMAIL_PASS is set:", !!process.env.GMAIL_PASS);
   }
 });
 // Trigger redeploy
+// ✅ Uses Secret Manager (future-safe)


### PR DESCRIPTION
## Summary
- add comment referencing Secret Manager for `sendStaffCredentials`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688c8cabbe408321b54c0cb2796c78e8