### PR TITLE
Update password label text

### DIFF
--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -50,7 +50,7 @@
     <label for="staff-name">Staff Name</label>
     <input type="text" id="staff-name" placeholder="Enter staff member’s name" required>
     <input type="email" id="staffEmailInput" placeholder="Email" required>
-    <label for="staff-password">Temporary Password</label>
+    <label for="staff-password">Initial Password</label>
     <input type="password" id="staff-password" placeholder="Temporary Password" required>
     <select id="staffRoleSelect">
       <option value="staff">staff</option>


### PR DESCRIPTION
## Summary
- fix label to read "Initial Password" on staff management page

## Testing
- `grep -n "Initial Password" -n public/manage-staff.html`

------
https://chatgpt.com/codex/tasks/task_e_688ca511d604832182a4b741a5cf9ce3