### PR TITLE
Add password toggle to manage staff page

### DIFF
--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -37,6 +37,20 @@
     form button:hover {
       background: #555;
     }
+    .password-container { position: relative; }
+    .password-container input { padding-right: 50px; }
+    .password-container button {
+      position: absolute;
+      top: 50%;
+      right: 10px;
+      transform: translateY(-50%);
+      background: #444;
+      border: none;
+      color: #fff;
+      padding: 4px 8px;
+      cursor: pointer;
+      z-index: 1;
+    }
     #staffList {
       margin-top: 20px;
       width: 100%;
@@ -88,7 +102,10 @@
     <input type="text" id="staff-name" placeholder="Enter staff member’s name" required>
     <input type="email" id="staffEmailInput" placeholder="Email" required>
     <label for="staff-password">New Password</label>
-    <input type="password" id="staff-password" placeholder="New Password" required>
+    <div class="password-container">
+      <input type="password" id="staff-password" placeholder="New Password" required>
+      <button type="button" id="toggleStaffPassword">Show</button>
+    </div>
     <select id="staffRoleSelect">
       <option value="staff">staff</option>
     </select>

--- a/public/manage-staff.js
+++ b/public/manage-staff.js
@@ -22,6 +22,15 @@ const functions = getFunctions(app);
     const createOverlay = document.getElementById('add-staff-loading');
     const successModal = document.getElementById('staffSuccessModal');
     const successOkBtn = document.getElementById('successOkBtn');
+    const staffPasswordInput = document.getElementById('staff-password');
+    const toggleStaffPasswordBtn = document.getElementById('toggleStaffPassword');
+    if (toggleStaffPasswordBtn && staffPasswordInput) {
+      toggleStaffPasswordBtn.addEventListener('click', () => {
+        const isPassword = staffPasswordInput.type === 'password';
+        staffPasswordInput.type = isPassword ? 'text' : 'password';
+        toggleStaffPasswordBtn.textContent = isPassword ? 'Hide' : 'Show';
+      });
+    }
     if (overlay) overlay.style.display = 'flex';
     onAuthStateChanged(auth, async user => {
       if (!user) {


### PR DESCRIPTION
## Summary
- replicate login page password toggle style and markup in `manage-staff.html`
- implement show/hide logic in `manage-staff.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688cb9ddeee883219dbb7e612e568768