### PR TITLE
Fix dashboard role check for new contractors

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -69,11 +69,11 @@
         try {
           const docRef = firebase.firestore().collection('contractors').doc(user.uid);
           const snap = await docRef.get();
-          const data = snap.exists ? snap.data() : {};
-          if (data.role !== 'contractor') {
+          if (!snap.exists) {
             window.location.replace('login.html');
             return;
           }
+          const data = snap.data() || {};
           const name = data.displayName || data.businessName || user.displayName || 'Contractor';
           document.getElementById('welcomeMessage').textContent = `Welcome, ${name}!`;
         } catch (err) {


### PR DESCRIPTION
## Summary
- only check if `contractors/{uid}` exists when verifying a user's access to dashboard

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688cc22949688321b8297180e3bfc869