### PR TITLE
Implement staff deletion

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -51,5 +51,15 @@ console.log("DEBUG - GMAIL_PASS is set:", !!process.env.GMAIL_PASS);
     return { success: false, error: error.message };
   }
 });
+
+exports.deleteStaffUser = onCall(async (request) => {
+  const { uid, contractorId } = request.data || {};
+  if (!uid || !contractorId) {
+    throw new functions.https.HttpsError('invalid-argument', 'Missing uid or contractorId');
+  }
+  await admin.firestore().doc(`contractors/${contractorId}/staff/${uid}`).delete();
+  await admin.auth().deleteUser(uid);
+  return { success: true };
+});
 // Trigger redeploy
 // ✅ Uses Secret Manager (future-safe)

--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -56,6 +56,22 @@
       width: 100%;
       max-width: 400px;
     }
+    #staffList li {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin: 4px 0;
+    }
+    #staffList button {
+      background: #333;
+      color: #fff;
+      border: none;
+      padding: 4px 8px;
+      cursor: pointer;
+    }
+    #staffList button:hover {
+      background: #555;
+    }
 
     /* Spinner overlay for creating staff */
     #add-staff-loading {
@@ -111,7 +127,7 @@
     </select>
     <button type="button" id="addStaffBtn">Add Staff Member</button>
   </form>
-  <div id="staffList"></div>
+  <ul id="staffList"></ul>
   <script type="module" src="manage-staff.js"></script>
 
   <div id="loading-overlay">


### PR DESCRIPTION
## Summary
- add new Cloud Function `deleteStaffUser`
- add delete button to staff list UI and style it
- load staff list on page open and refresh after deleting or adding staff

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688d3033762c8321950cfc53d94242e5