### PR TITLE
Add live staff table with status display

### DIFF
--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -51,25 +51,37 @@
       cursor: pointer;
       z-index: 1;
     }
-    #staffList {
+    #staffSummary {
       margin-top: 20px;
+      font-size: 18px;
+    }
+    #staffTable {
+      border-collapse: collapse;
       width: 100%;
-      max-width: 400px;
+      max-width: 600px;
+      margin-top: 10px;
     }
-    #staffList li {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      margin: 4px 0;
+    #staffTable th,
+    #staffTable td {
+      border: 1px solid #555;
+      padding: 8px 12px;
+      text-align: left;
     }
-    #staffList button {
+    #staffTable th {
+      background: #222;
+    }
+    #staffTable tbody tr:hover {
+      background: #111;
+    }
+    #staffTable button {
       background: #333;
       color: #fff;
       border: none;
       padding: 4px 8px;
       cursor: pointer;
+      border-radius: 4px;
     }
-    #staffList button:hover {
+    #staffTable button:hover {
       background: #555;
     }
 
@@ -127,7 +139,19 @@
     </select>
     <button type="button" id="addStaffBtn">Add Staff Member</button>
   </form>
-  <ul id="staffList"></ul>
+  <p id="staffSummary"></p>
+  <table id="staffTable">
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>Name</th>
+        <th>Email</th>
+        <th>Status</th>
+        <th>Action</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
   <script type="module" src="manage-staff.js"></script>
 
   <div id="loading-overlay">


### PR DESCRIPTION
## Summary
- style manage staff page for a table view
- show staff count summary and data table
- populate table with online/offline status
- store contractor id in localStorage for reuse

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688d3ab1b01c8321bd6b8ebf097a1509