### PR TITLE
Add staff deletion trigger

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -79,3 +79,22 @@ exports.deleteStaffUser = onCall(async (request) => {
 });
 // Trigger redeploy
 // ✅ Uses Secret Manager (future-safe)
+
+// Listen for deleted staff user documents
+exports.onStaffDeleted = functions.firestore
+  .document('contractors/{contractorId}/staff/{staffId}')
+  .onDelete((snap, context) => {
+    const { contractorId, staffId } = context.params;
+    const data = snap.data() || {};
+    const { name, email } = data;
+
+    const deletedAt = new Date().toISOString();
+
+    console.log('Staff deleted', {
+      contractorId,
+      staffId,
+      name,
+      email,
+      deletedAt,
+    });
+  });


### PR DESCRIPTION
## Summary
- add `onStaffDeleted` Cloud Function to log staff deletions

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_688d44776c488321840c3db0f328e6bc