### PR TITLE
Add deleted staff search filter

### DIFF
--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -92,6 +92,21 @@
       background: #555;
     }
 
+    #deletedStaffSearch {
+      margin-top: 10px;
+      margin-bottom: 10px;
+      width: 100%;
+      max-width: 600px;
+      padding: 8px;
+      background: #222;
+      color: #fff;
+      border: 1px solid #555;
+      border-radius: 4px;
+    }
+    #deletedStaffSearch::placeholder {
+      color: #bbb;
+    }
+
     /* Spinner overlay for creating staff */
     #add-staff-loading {
       position: fixed;
@@ -213,6 +228,7 @@
     <tbody></tbody>
   </table>
   <h3>Deleted Staff</h3>
+  <input type="text" id="deletedStaffSearch" placeholder="Search deleted staff…">
   <table id="deletedStaffTable">
     <thead>
       <tr>

--- a/public/manage-staff.js
+++ b/public/manage-staff.js
@@ -132,6 +132,19 @@ async function loadDeletedStaff(contractorId) {
   tbody.querySelectorAll('.restoreStaffBtn').forEach(btn => {
     btn.addEventListener('click', () => restoreStaff(btn));
   });
+
+  applyDeletedStaffFilter();
+}
+
+function applyDeletedStaffFilter() {
+  const input = document.getElementById('deletedStaffSearch');
+  const filter = input ? input.value.trim().toLowerCase() : '';
+  const rows = document.querySelectorAll('#deletedStaffTable tbody tr');
+  rows.forEach(row => {
+    const name = row.children[0]?.textContent.toLowerCase() || '';
+    const email = row.children[1]?.textContent.toLowerCase() || '';
+    row.style.display = !filter || name.includes(filter) || email.includes(filter) ? '' : 'none';
+  });
 }
 
 async function deleteStaff(btn) {
@@ -229,6 +242,11 @@ async function restoreStaff(btn) {
       localStorage.setItem('contractor_id', contractorUid);
       await loadStaffList(contractorUid);
       await loadDeletedStaff(contractorUid);
+
+      const deletedSearchInput = document.getElementById('deletedStaffSearch');
+      if (deletedSearchInput) {
+        deletedSearchInput.addEventListener('input', applyDeletedStaffFilter);
+      }
 
       const addBtn = document.getElementById('addStaffBtn');
       if (successOkBtn) {


### PR DESCRIPTION
## Summary
- add styled search box above deleted staff table
- filter deleted staff rows by name or email without refetching

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check public/manage-staff.js`


------
https://chatgpt.com/codex/tasks/task_e_688d9fda4eb08321a11a8af586700394