### PR TITLE
feat: toggle deleted staff table

### DIFF
--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -107,6 +107,31 @@
       color: #bbb;
     }
 
+    #toggleDeletedStaffBtn {
+      margin-top: 30px;
+      background: #333;
+      color: #fff;
+      border: none;
+      padding: 8px 12px;
+      cursor: pointer;
+      border-radius: 4px;
+    }
+    #toggleDeletedStaffBtn:hover {
+      background: #555;
+    }
+    #deletedStaffSection {
+      width: 100%;
+      max-width: 600px;
+      transition: max-height 0.3s ease, opacity 0.3s ease;
+      overflow: hidden;
+      max-height: 1000px;
+      opacity: 1;
+    }
+    #deletedStaffSection.collapsed {
+      max-height: 0;
+      opacity: 0;
+    }
+
     .table-heading {
       width: 100%;
       max-width: 600px;
@@ -239,19 +264,22 @@
     </thead>
     <tbody></tbody>
   </table>
-  <h3 id="deletedStaffHeading" class="table-heading">Deleted Staff</h3>
-  <input type="text" id="deletedStaffSearch" placeholder="Search deleted staff…">
-  <table id="deletedStaffTable">
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Email</th>
-        <th>Deleted</th>
-        <th>Action</th>
-      </tr>
-    </thead>
-    <tbody></tbody>
-  </table>
+  <button id="toggleDeletedStaffBtn">🔼 Hide Deleted Staff</button>
+  <div id="deletedStaffSection">
+    <h3 id="deletedStaffHeading" class="table-heading">Deleted Staff</h3>
+    <input type="text" id="deletedStaffSearch" placeholder="Search deleted staff…">
+    <table id="deletedStaffTable">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Email</th>
+          <th>Deleted</th>
+          <th>Action</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
   <script type="module" src="manage-staff.js"></script>
 
   <div id="loading-overlay">

--- a/public/manage-staff.js
+++ b/public/manage-staff.js
@@ -208,6 +208,14 @@ async function restoreStaff(btn) {
     confirmMessage = document.getElementById('confirmMessage');
     confirmYesBtn = document.getElementById('confirmYesBtn');
     confirmCancelBtn = document.getElementById('confirmCancelBtn');
+    const toggleDeletedStaffBtn = document.getElementById('toggleDeletedStaffBtn');
+    const deletedStaffSection = document.getElementById('deletedStaffSection');
+    if (toggleDeletedStaffBtn && deletedStaffSection) {
+      toggleDeletedStaffBtn.addEventListener('click', () => {
+        const collapsed = deletedStaffSection.classList.toggle('collapsed');
+        toggleDeletedStaffBtn.textContent = collapsed ? '🔽 Show Deleted Staff' : '🔼 Hide Deleted Staff';
+      });
+    }
     const staffPasswordInput = document.getElementById('staff-password');
     const toggleStaffPasswordBtn = document.getElementById('toggleStaffPassword');
     if (toggleStaffPasswordBtn && staffPasswordInput) {


### PR DESCRIPTION
## Summary
- add dark-styled toggle button to show or hide deleted staff section
- hide table and search input with smooth slide/fade when collapsed
- default to expanded state and update button text accordingly

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688da5f311a08321ac5255f941c9b46e