### PR TITLE
Use rotating arrow to toggle deleted staff list

### DIFF
--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -107,17 +107,31 @@
       color: #bbb;
     }
 
-    #toggleDeletedStaffBtn {
+    .collapsible-header {
+      display: flex;
+      align-items: center;
+      width: 100%;
+      max-width: 600px;
       margin-top: 30px;
-      background: #333;
-      color: #fff;
-      border: none;
-      padding: 8px 12px;
+      margin-bottom: 10px;
       cursor: pointer;
-      border-radius: 4px;
+      user-select: none;
     }
-    #toggleDeletedStaffBtn:hover {
-      background: #555;
+    .collapsible-header:hover {
+      color: #bbb;
+    }
+    .collapsible-header .arrow {
+      display: inline-block;
+      margin-right: 8px;
+      transition: transform 0.3s ease;
+    }
+    .collapsible-header.expanded .arrow {
+      transform: rotate(90deg);
+    }
+    .collapsible-header h3 {
+      margin: 0;
+      width: auto;
+      max-width: none;
     }
     #deletedStaffSection {
       width: 100%;
@@ -138,9 +152,6 @@
       margin-top: 20px;
       margin-bottom: 10px;
       text-align: left;
-    }
-    #deletedStaffHeading {
-      margin-top: 50px;
     }
 
     /* Spinner overlay for creating staff */
@@ -264,9 +275,11 @@
     </thead>
     <tbody></tbody>
   </table>
-  <button id="toggleDeletedStaffBtn">🔼 Hide Deleted Staff</button>
-  <div id="deletedStaffSection">
+  <div id="deletedStaffHeader" class="collapsible-header">
+    <span class="arrow">▶</span>
     <h3 id="deletedStaffHeading" class="table-heading">Deleted Staff</h3>
+  </div>
+  <div id="deletedStaffSection">
     <input type="text" id="deletedStaffSearch" placeholder="Search deleted staff…">
     <table id="deletedStaffTable">
       <thead>

--- a/public/manage-staff.js
+++ b/public/manage-staff.js
@@ -103,18 +103,14 @@ async function loadStaffList(contractorId) {
 
   await loadDeletedStaff(contractorId);
   const deletedRows = document.querySelectorAll('#deletedStaffTable tbody tr').length;
-  const toggleDeletedStaffBtn = document.getElementById('toggleDeletedStaffBtn');
+  const deletedStaffHeader = document.getElementById('deletedStaffHeader');
   const deletedStaffSection = document.getElementById('deletedStaffSection');
-  if (toggleDeletedStaffBtn && deletedStaffSection) {
+  if (deletedStaffHeader && deletedStaffSection) {
+    const collapsed = deletedRows === 0 ? true : localStorage.getItem(DELETED_STAFF_STATE_KEY) === 'collapsed';
+    deletedStaffSection.classList.toggle('collapsed', collapsed);
+    deletedStaffHeader.classList.toggle('expanded', !collapsed);
     if (deletedRows === 0) {
-      deletedStaffSection.classList.add('collapsed');
-      toggleDeletedStaffBtn.textContent = '🔽 Show Deleted Staff';
       localStorage.setItem(DELETED_STAFF_STATE_KEY, 'collapsed');
-    } else {
-      const storedState = localStorage.getItem(DELETED_STAFF_STATE_KEY);
-      const collapsed = storedState === 'collapsed';
-      deletedStaffSection.classList.toggle('collapsed', collapsed);
-      toggleDeletedStaffBtn.textContent = collapsed ? '🔽 Show Deleted Staff' : '🔼 Hide Deleted Staff';
     }
   }
 }
@@ -224,20 +220,16 @@ async function restoreStaff(btn) {
     confirmMessage = document.getElementById('confirmMessage');
     confirmYesBtn = document.getElementById('confirmYesBtn');
     confirmCancelBtn = document.getElementById('confirmCancelBtn');
-    const toggleDeletedStaffBtn = document.getElementById('toggleDeletedStaffBtn');
+    const deletedStaffHeader = document.getElementById('deletedStaffHeader');
     const deletedStaffSection = document.getElementById('deletedStaffSection');
-    if (toggleDeletedStaffBtn && deletedStaffSection) {
+    if (deletedStaffHeader && deletedStaffSection) {
       const storedState = localStorage.getItem(DELETED_STAFF_STATE_KEY);
-      if (storedState === 'collapsed') {
-        deletedStaffSection.classList.add('collapsed');
-        toggleDeletedStaffBtn.textContent = '🔽 Show Deleted Staff';
-      } else {
-        deletedStaffSection.classList.remove('collapsed');
-        toggleDeletedStaffBtn.textContent = '🔼 Hide Deleted Staff';
-      }
-      toggleDeletedStaffBtn.addEventListener('click', () => {
+      const collapsed = storedState === 'collapsed';
+      deletedStaffSection.classList.toggle('collapsed', collapsed);
+      deletedStaffHeader.classList.toggle('expanded', !collapsed);
+      deletedStaffHeader.addEventListener('click', () => {
         const collapsed = deletedStaffSection.classList.toggle('collapsed');
-        toggleDeletedStaffBtn.textContent = collapsed ? '🔽 Show Deleted Staff' : '🔼 Hide Deleted Staff';
+        deletedStaffHeader.classList.toggle('expanded', !collapsed);
         localStorage.setItem(DELETED_STAFF_STATE_KEY, collapsed ? 'collapsed' : 'expanded');
       });
     }


### PR DESCRIPTION
## Summary
- Replace "Show/Hide Deleted Staff" text button with a collapsible header using a rotating arrow icon
- Persist deleted staff section state in localStorage and rotate arrow when expanded

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688dadf2471483219cedbb3102606f32