### PR TITLE
feat: add dashboard return button to manage staff page

### DIFF
--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -247,6 +247,9 @@
 </head>
 <body>
   <h2>Manage Staff</h2>
+  <div class="tabs">
+    <button id="back-to-dashboard-btn" class="tab-button" style="display: none;">⬅ Return to Dashboard</button>
+  </div>
   <form id="staffForm">
     <label for="staff-name">Staff Name</label>
     <input type="text" id="staff-name" placeholder="Enter staff member’s name" required>

--- a/public/manage-staff.js
+++ b/public/manage-staff.js
@@ -256,6 +256,13 @@ async function restoreStaff(btn) {
         window.location.replace('login.html');
         return;
       }
+      const backBtn = document.getElementById('back-to-dashboard-btn');
+      if (backBtn) {
+        backBtn.style.display = 'inline-block';
+        backBtn.addEventListener('click', () => {
+          window.location.href = 'dashboard.html';
+        });
+      }
     } catch (err) {
       console.error('Failed to verify role', err);
       window.location.replace('login.html');


### PR DESCRIPTION
## Summary
- add "⬅ Return to Dashboard" button to Manage Staff page
- show button only for contractor users and link back to dashboard

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688db3b075d4832194c5c567fdd8dba6