### PR TITLE
feat: hide content until auth check completes

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -41,23 +41,25 @@
   <script type="module" src="auth.js"></script>
 </head>
 <body>
-  <div class="logo-container">
-    <img src="logo.png" alt="SHEΔR iQ logo" />
-    <h2 id="welcomeMessage">Welcome</h2>
-  </div>
-  <div id="buttonContainer">
-    <button id="btnManageStaff">Manage Staff</button>
-    <button id="btnViewSavedSessions">View Saved Sessions</button>
-    <button id="btnStationSummary">Station Summary</button>
-    <button id="btnLoadPrevious">Load Previous Session</button>
-    <button id="btnChangePin">Change Contractor PIN</button>
-    <button id="btnSaveBackup">Save &amp; Backup Options</button>
-    <button id="btnNewDayReset">New Day Reset</button>
-    <button id="btnEditCurrent">Edit Current Session Details</button>
-    <button id="btnExportAll">Export All Sessions</button>
-    <button id="btnSetDefaultStart">Set Default Start Time / Workday Type</button>
-    <button id="btnSettings">Settings / Preferences</button>
-    <button id="logoutBtn" class="btn btn-primary">Logout</button>
+  <div id="page-content" style="display: none;">
+    <div class="logo-container">
+      <img src="logo.png" alt="SHEΔR iQ logo" />
+      <h2 id="welcomeMessage">Welcome</h2>
+    </div>
+    <div id="buttonContainer">
+      <button id="btnManageStaff">Manage Staff</button>
+      <button id="btnViewSavedSessions">View Saved Sessions</button>
+      <button id="btnStationSummary">Station Summary</button>
+      <button id="btnLoadPrevious">Load Previous Session</button>
+      <button id="btnChangePin">Change Contractor PIN</button>
+      <button id="btnSaveBackup">Save &amp; Backup Options</button>
+      <button id="btnNewDayReset">New Day Reset</button>
+      <button id="btnEditCurrent">Edit Current Session Details</button>
+      <button id="btnExportAll">Export All Sessions</button>
+      <button id="btnSetDefaultStart">Set Default Start Time / Workday Type</button>
+      <button id="btnSettings">Settings / Preferences</button>
+      <button id="logoutBtn" class="btn btn-primary">Logout</button>
+    </div>
   </div>
 
   <script type="module">
@@ -79,6 +81,8 @@
           const data = snap.data() || {};
           const name = data.displayName || data.businessName || user.displayName || 'Contractor';
           document.getElementById('welcomeMessage').textContent = `Welcome, ${name}!`;
+          const pageContent = document.getElementById('page-content');
+          if (pageContent) pageContent.style.display = 'block';
         } catch (err) {
           console.error('Failed to verify role', err);
           window.location.replace('login.html');

--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -246,58 +246,60 @@
   </style>
 </head>
 <body>
-  <div class="logo-container">
-    <img src="logo.png" alt="SHEΔR iQ logo" />
-    <h2>Manage Staff</h2>
-  </div>
-  <div class="tabs">
-    <button id="back-to-dashboard-btn" class="tab-button" style="display: none;">⬅ Return to Dashboard</button>
-  </div>
-  <form id="staffForm">
-    <label for="staff-name">Staff Name</label>
-    <input type="text" id="staff-name" placeholder="Enter staff member’s name" required>
-    <input type="email" id="staffEmailInput" placeholder="Email" required>
-    <label for="staff-password">New Password</label>
-    <div class="password-container">
-      <input type="password" id="staff-password" placeholder="New Password" required>
-      <button type="button" id="toggleStaffPassword">Show</button>
+  <div id="page-content" style="display: none;">
+    <div class="logo-container">
+      <img src="logo.png" alt="SHEΔR iQ logo" />
+      <h2>Manage Staff</h2>
     </div>
-    <select id="staffRoleSelect">
-      <option value="staff">staff</option>
-    </select>
-    <button type="button" id="addStaffBtn">Add Staff Member</button>
-  </form>
-  <p id="staffSummary"></p>
-  <h3 id="activeStaffHeading" class="table-heading">Active Staff</h3>
-  <table id="staffTable">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>Name</th>
-        <th>Email</th>
-        <th>Status</th>
-        <th>Action</th>
-      </tr>
-    </thead>
-    <tbody></tbody>
-  </table>
-  <div id="deletedStaffHeader" class="collapsible-header">
-    <span class="arrow">▶</span>
-    <h3 id="deletedStaffHeading" class="table-heading">Deleted Staff</h3>
-  </div>
-  <div id="deletedStaffSection">
-    <input type="text" id="deletedStaffSearch" placeholder="Search deleted staff…">
-    <table id="deletedStaffTable">
+    <div class="tabs">
+      <button id="back-to-dashboard-btn" class="tab-button" style="display: none;">⬅ Return to Dashboard</button>
+    </div>
+    <form id="staffForm">
+      <label for="staff-name">Staff Name</label>
+      <input type="text" id="staff-name" placeholder="Enter staff member’s name" required>
+      <input type="email" id="staffEmailInput" placeholder="Email" required>
+      <label for="staff-password">New Password</label>
+      <div class="password-container">
+        <input type="password" id="staff-password" placeholder="New Password" required>
+        <button type="button" id="toggleStaffPassword">Show</button>
+      </div>
+      <select id="staffRoleSelect">
+        <option value="staff">staff</option>
+      </select>
+      <button type="button" id="addStaffBtn">Add Staff Member</button>
+    </form>
+    <p id="staffSummary"></p>
+    <h3 id="activeStaffHeading" class="table-heading">Active Staff</h3>
+    <table id="staffTable">
       <thead>
         <tr>
+          <th>#</th>
           <th>Name</th>
           <th>Email</th>
-          <th>Deleted</th>
+          <th>Status</th>
           <th>Action</th>
         </tr>
       </thead>
       <tbody></tbody>
     </table>
+    <div id="deletedStaffHeader" class="collapsible-header">
+      <span class="arrow">▶</span>
+      <h3 id="deletedStaffHeading" class="table-heading">Deleted Staff</h3>
+    </div>
+    <div id="deletedStaffSection">
+      <input type="text" id="deletedStaffSearch" placeholder="Search deleted staff…">
+      <table id="deletedStaffTable">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Email</th>
+            <th>Deleted</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
   </div>
   <script type="module" src="manage-staff.js"></script>
 

--- a/public/manage-staff.js
+++ b/public/manage-staff.js
@@ -211,6 +211,7 @@ async function restoreStaff(btn) {
 
   document.addEventListener('DOMContentLoaded', () => {
     const overlay = document.getElementById('loading-overlay');
+    const pageContent = document.getElementById('page-content');
     const createOverlay = document.getElementById('add-staff-loading');
     const successModal = document.getElementById('staffSuccessModal');
     const successOkBtn = document.getElementById('successOkBtn');
@@ -247,28 +248,30 @@ async function restoreStaff(btn) {
       if (!user) {
         window.location.replace('login.html');
         return;
-    }
-    try {
-      const docRef = doc(collection(db, 'contractors'), user.uid);
-      const snap = await getDoc(docRef);
-      const data = snap.exists() ? snap.data() : {};
-      if (data.role !== 'contractor') {
+      }
+      try {
+        const docRef = doc(collection(db, 'contractors'), user.uid);
+        const snap = await getDoc(docRef);
+        const data = snap.exists() ? snap.data() : {};
+        if (data.role !== 'contractor') {
+          window.location.replace('login.html');
+          return;
+        }
+        const backBtn = document.getElementById('back-to-dashboard-btn');
+        if (backBtn) {
+          backBtn.style.display = 'inline-block';
+          backBtn.addEventListener('click', () => {
+            window.location.href = 'dashboard.html';
+          });
+        }
+        if (pageContent) pageContent.style.display = 'block';
+      } catch (err) {
+        console.error('Failed to verify role', err);
         window.location.replace('login.html');
         return;
+      } finally {
+        if (overlay) overlay.style.display = 'none';
       }
-      const backBtn = document.getElementById('back-to-dashboard-btn');
-      if (backBtn) {
-        backBtn.style.display = 'inline-block';
-        backBtn.addEventListener('click', () => {
-          window.location.href = 'dashboard.html';
-        });
-      }
-    } catch (err) {
-      console.error('Failed to verify role', err);
-      window.location.replace('login.html');
-      return;
-    }
-      if (overlay) overlay.style.display = 'none';
 
       const contractorUid = user.uid;
       localStorage.setItem('contractor_id', contractorUid);


### PR DESCRIPTION
## Summary
- hide dashboard and manage staff page content until Firebase auth/role checks finish
- show page content only after auth success and remove loading overlay

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688dc35e75a483218e6f0c27586b9ce4