### PR TITLE
Enable viewing saved sessions from dashboard

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1,15 +1,21 @@
 import { handleLogout } from './auth.js';
 
 document.addEventListener('DOMContentLoaded', () => {
-  const logoutBtn = document.getElementById('logoutBtn');
-  if (logoutBtn) {
-    logoutBtn.addEventListener('click', handleLogout);
-  }
+  firebase.auth().onAuthStateChanged(user => {
+    if (!user) {
+      return;
+    }
 
-  const viewSessionsBtn = document.getElementById('btnViewSavedSessions');
-  if (viewSessionsBtn) {
-    viewSessionsBtn.addEventListener('click', () => {
-      window.location.href = 'view-sessions.html';
-    });
-  }
+    const logoutBtn = document.getElementById('logoutBtn');
+    if (logoutBtn) {
+      logoutBtn.addEventListener('click', handleLogout);
+    }
+
+    const btnViewSavedSessions = document.getElementById('btnViewSavedSessions');
+    if (btnViewSavedSessions) {
+      btnViewSavedSessions.addEventListener('click', () => {
+        window.location.href = 'view-sessions.html';
+      });
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Ensure dashboard listens for auth ready and wires up View Saved Sessions button

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688de2ecfd0c832185c0a941bef84b50