### PR TITLE
Add return to active session button

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -47,6 +47,7 @@
       <button id="btnViewSavedSessions" class="tab-button">📂 View Saved Sessions</button>
       <button id="btnLoadPrevious" class="tab-button">Load Previous Session</button>
       <button id="btnChangePin" class="tab-button">Change Contractor PIN</button>
+      <button id="btnReturnToSession" class="tab-button" style="display: none;">⏱️ Return to Active Session</button>
       <button id="btnSaveBackup" class="tab-button">Save &amp; Backup Options</button>
       <button id="btnNewDayReset" class="tab-button">New Day Reset</button>
       <button id="btnEditCurrent" class="tab-button">Edit Current Session Details</button>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -17,5 +17,14 @@ document.addEventListener('DOMContentLoaded', () => {
         window.location.href = 'view-sessions.html';
       });
     }
+
+    const btnReturnToSession = document.getElementById('btnReturnToSession');
+    const activeSession = localStorage.getItem('tally_session');
+    if (btnReturnToSession && activeSession) {
+      btnReturnToSession.style.display = 'block';
+      btnReturnToSession.addEventListener('click', () => {
+        window.location.href = 'tally.html';
+      });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Add hidden "Return to Active Session" button on dashboard
- Reveal button when a tally session exists and navigate back to tally

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688de65cdd6c83218ba3c65df0420a4d