### PR TITLE
Add Start New Day button to dashboard

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -48,6 +48,7 @@
       <button id="btnLoadPrevious" class="tab-button">Load Previous Session</button>
       <button id="btnChangePin" class="tab-button">Change Contractor PIN</button>
       <button id="btnReturnToSession" class="tab-button" style="display: none;"> Return to Active Session</button>
+      <button id="btnStartNewDay" class="tab-button">Start New Day</button>
       <button id="btnSaveBackup" class="tab-button">Save &amp; Backup Options</button>
       <button id="btnNewDayReset" class="tab-button">New Day Reset</button>
       <button id="btnEditCurrent" class="tab-button">Edit Current Session Details</button>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -26,5 +26,12 @@ document.addEventListener('DOMContentLoaded', () => {
         window.location.href = 'tally.html';
       });
     }
+
+    const btnStartNewDay = document.getElementById('btnStartNewDay');
+    if (btnStartNewDay) {
+      btnStartNewDay.addEventListener('click', () => {
+        window.location.href = 'tally.html?newDay=true';
+      });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Add Start New Day button beneath Return to Active Session in dashboard
- Wire new button to open `tally.html?newDay=true`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688decaab67c8321a80ed64e067d265b