### PR TITLE
Clean up dashboard buttons

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -45,15 +45,9 @@
       <button id="btnManageStaff" class="tab-button">Manage Staff</button>
       <button id="btnStationSummary" class="tab-button">Station Summary</button>
       <button id="btnViewSavedSessions" class="tab-button">View Saved Sessions</button>
-      <button id="btnLoadPrevious" class="tab-button">Load Previous Session</button>
       <button id="btnChangePin" class="tab-button">Change Contractor PIN</button>
-      <button id="btnReturnToSession" class="tab-button" style="display: none;"> Return to Active Session</button>
+      <button id="btnReturnToActive" class="tab-button" style="display: none;"> Return to Active Session</button>
       <button id="btnStartNewDay" class="tab-button">Start New Day</button>
-      <button id="btnSaveBackup" class="tab-button">Save &amp; Backup Options</button>
-      <button id="btnNewDayReset" class="tab-button">New Day Reset</button>
-      <button id="btnEditCurrent" class="tab-button">Edit Current Session Details</button>
-      <button id="btnExportAll" class="tab-button">Export All Sessions</button>
-      <button id="btnSetDefaultStart" class="tab-button">Set Default Start Time / Workday Type</button>
       <button id="btnSettings" class="tab-button">Settings / Preferences</button>
       <button id="logoutBtn" class="tab-button">Logout</button>
     </div>
@@ -87,39 +81,6 @@
           if (overlay) overlay.style.display = 'none';
         }
       });
-    });
-  </script>
-  <script>
-    // Navigation button handlers
-    document.getElementById('btnManageStaff')?.addEventListener('click', () => {
-      window.location.href = 'manage-staff.html';
-    });
-    document.getElementById('btnStationSummary')?.addEventListener('click', () => {
-      window.location.href = 'station-summary.html';
-    });
-    document.getElementById('btnLoadSession')?.addEventListener('click', () => {
-      window.location.href = 'load-session.html';
-    });
-    document.getElementById('btnChangePIN')?.addEventListener('click', () => {
-      window.location.href = 'change-pin.html';
-    });
-    document.getElementById('btnBackup')?.addEventListener('click', () => {
-      window.location.href = 'backup-options.html';
-    });
-    document.getElementById('btnNewDay')?.addEventListener('click', () => {
-      window.location.href = 'tally.html?newDay=true';
-    });
-    document.getElementById('btnEditSession')?.addEventListener('click', () => {
-      window.location.href = 'edit-session.html';
-    });
-    document.getElementById('btnExportAll')?.addEventListener('click', () => {
-      window.location.href = 'export-all.html';
-    });
-    document.getElementById('btnSetDefaults')?.addEventListener('click', () => {
-      window.location.href = 'set-defaults.html';
-    });
-    document.getElementById('btnSettings')?.addEventListener('click', () => {
-      window.location.href = 'settings.html';
     });
   </script>
   <script type="module" src="dashboard.js"></script>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -11,6 +11,27 @@ document.addEventListener('DOMContentLoaded', () => {
       logoutBtn.addEventListener('click', handleLogout);
     }
 
+    const btnManageStaff = document.getElementById('btnManageStaff');
+    if (btnManageStaff) {
+      btnManageStaff.addEventListener('click', () => {
+        window.location.href = 'manage-staff.html';
+      });
+    }
+
+    const btnStationSummary = document.getElementById('btnStationSummary');
+    if (btnStationSummary) {
+      btnStationSummary.addEventListener('click', () => {
+        window.location.href = 'station-summary.html';
+      });
+    }
+
+    const btnChangePin = document.getElementById('btnChangePin');
+    if (btnChangePin) {
+      btnChangePin.addEventListener('click', () => {
+        window.location.href = 'change-pin.html';
+      });
+    }
+
     const btnViewSavedSessions = document.getElementById('btnViewSavedSessions');
     if (btnViewSavedSessions) {
       btnViewSavedSessions.addEventListener('click', () => {
@@ -18,11 +39,11 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     }
 
-    const btnReturnToSession = document.getElementById('btnReturnToSession');
+    const btnReturnToActive = document.getElementById('btnReturnToActive');
     const activeSession = localStorage.getItem('tally_session');
-    if (btnReturnToSession && activeSession) {
-      btnReturnToSession.style.display = 'block';
-      btnReturnToSession.addEventListener('click', () => {
+    if (btnReturnToActive && activeSession) {
+      btnReturnToActive.style.display = 'block';
+      btnReturnToActive.addEventListener('click', () => {
         window.location.href = 'tally.html';
       });
     }


### PR DESCRIPTION
## Summary
- Remove unused session management buttons from dashboard
- Wire remaining dashboard buttons via centralized script

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688df0815f2c8321bebccd1e956592d7