### PR TITLE
Add contractor view sessions page

### DIFF
--- a/public/view-sessions.html
+++ b/public/view-sessions.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>View Saved Sessions - SHEΔR iQ</title>
+  <link rel="stylesheet" href="styles.css">
+  <style>
+    body {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 20px;
+      background: #000;
+      color: #fff;
+      font-family: Arial, sans-serif;
+    }
+  </style>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
+  <script src="firebase-init.js"></script>
+</head>
+<body>
+  <div id="page-content" style="display: none;">
+    <div class="logo-container">
+      <img src="logo.png" alt="SHEΔR iQ logo" />
+      <h2>View Saved Sessions</h2>
+    </div>
+    <div class="tabs">
+      <button id="backToDashboard" class="tab-button" style="display: none;">⬅ Return to Dashboard</button>
+    </div>
+    <div id="sessionList">
+      <!-- Sessions will be loaded here -->
+    </div>
+  </div>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const overlay = document.getElementById('loading-overlay');
+      if (overlay) overlay.style.display = 'flex';
+      firebase.auth().onAuthStateChanged(async user => {
+        if (!user) {
+          window.location.replace('login.html');
+          return;
+        }
+        try {
+          const doc = await firebase.firestore().collection('contractors').doc(user.uid).get();
+          if (!doc.exists) {
+            window.location.replace('login.html');
+            return;
+          }
+          const page = document.getElementById('page-content');
+          if (page) page.style.display = 'block';
+          const dashBtn = document.getElementById('backToDashboard');
+          if (dashBtn) dashBtn.style.display = 'inline-block';
+        } catch (err) {
+          console.error('Failed to verify contractor', err);
+          window.location.replace('login.html');
+        } finally {
+          if (overlay) overlay.style.display = 'none';
+        }
+      });
+    });
+  </script>
+
+  <script type="module" src="view-sessions.js"></script>
+
+  <div id="loading-overlay">
+    <div class="circle-spinner"></div>
+    <div>Loading…</div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add view-sessions.html with dark theme, contractor auth check, and session list placeholder
- Include spinner and dashboard return button for contractors

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688df41228cc8321a9ff899b3c7dce2f