### PR TITLE
Load sessions via localStorage

### DIFF
--- a/public/tally.js
+++ b/public/tally.js
@@ -2319,6 +2319,28 @@ function restoreTodaySession() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+    const params = new URLSearchParams(window.location.search);
+    const isLoadedSession = params.get('loadedSession') === 'true';
+    const isNewDay = params.get('newDay') === 'true';
+
+    if (isLoadedSession) {
+        const json = localStorage.getItem('active_session');
+        if (json) {
+            try {
+                const session = JSON.parse(json);
+                const viewOnly = localStorage.getItem('viewOnlyMode') === 'true';
+                session.viewOnly = viewOnly;
+                const fsId = localStorage.getItem('firestoreSessionId');
+                if (fsId) firestoreSessionId = fsId;
+                loadSessionObject(session);
+            } catch (e) {
+                console.error('Failed to parse active_session', e);
+            }
+        }
+    } else if (isNewDay) {
+        resetForNewDay();
+    }
+
     const storedRole = sessionStorage.getItem('userRole');
     if (storedRole) updateUIForRole(storedRole);
     document.querySelectorAll('.tab-button').forEach(btn => {

--- a/public/view-sessions.js
+++ b/public/view-sessions.js
@@ -65,8 +65,12 @@ async function fetchSessions(contractorId) {
       viewBtn.textContent = 'View';
       viewBtn.className = 'tab-button';
       viewBtn.addEventListener('click', () => {
-        localStorage.setItem('selected_session_id', doc.id);
-        window.location.href = `tally.html?sessionId=${encodeURIComponent(doc.id)}&viewOnly=1`;
+        // Save session data and ID to localStorage
+        localStorage.setItem('active_session', JSON.stringify(data));
+        localStorage.setItem('firestoreSessionId', doc.id);
+        localStorage.setItem('viewOnlyMode', 'true');
+        // Redirect to tally page with loadedSession flag
+        window.location.href = 'tally.html?loadedSession=true';
       });
       btns.appendChild(viewBtn);
 
@@ -77,8 +81,11 @@ async function fetchSessions(contractorId) {
       editBtn.addEventListener('click', () => {
         const pin = prompt('\uD83D\uDD10 Enter Contractor PIN to edit:');
         if (pin === '1234') {
-          localStorage.setItem('selected_session_id', doc.id);
-          window.location.href = `tally.html?sessionId=${encodeURIComponent(doc.id)}`;
+          const editable = { ...data, viewOnly: false };
+          localStorage.setItem('active_session', JSON.stringify(editable));
+          localStorage.setItem('firestoreSessionId', doc.id);
+          localStorage.setItem('viewOnlyMode', 'false');
+          window.location.href = 'tally.html?loadedSession=true';
         } else if (pin !== null) {
           alert('Incorrect PIN');
         }


### PR DESCRIPTION
## Summary
- Load selected sessions into tally via localStorage and set view/edit modes
- Handle loadedSession query param in tally.js and ignore newDay when present

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688dff4038188321a8912180eda231e1