### PR TITLE
Ensure Farm Summary button navigates correctly

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -19,13 +19,10 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     const btnFarmSummary = document.getElementById('btnFarmSummary');
-    // Redirect to the farm summary page instead of the tally sheet
-    if (btnFarmSummary) {
-      btnFarmSummary.addEventListener('click', (event) => {
-        event.preventDefault();
-        window.location.href = 'farm-summary.html';
-      });
-    }
+    btnFarmSummary?.addEventListener('click', (event) => {
+      event.preventDefault();
+      window.location.href = 'farm-summary.html';
+    });
 
     const btnChangePin = document.getElementById('btnChangePin');
     if (btnChangePin) {

--- a/public/farm-summary.html
+++ b/public/farm-summary.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Farm Summary - SHEAR iQ</title>
+  <link rel="stylesheet" href="styles.css">
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
+  <script src="firebase-init.js"></script>
+  <script type="module" src="auth.js"></script>
+</head>
+<body>
+  <div class="logo-container">
+    <img src="logo.png" alt="SHEΔR iQ logo" />
+    <h2>Farm Summary</h2>
+  </div>
+  <button id="backToDashboard" class="tab-button">⬅ Return to Dashboard</button>
+  <script type="module">
+    const backBtn = document.getElementById('backToDashboard');
+    backBtn?.addEventListener('click', (e) => {
+      e.preventDefault();
+      window.location.href = 'dashboard.html';
+    });
+  </script>
+</body>
+</html>

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,6 +1,7 @@
 const CACHE_NAME = 'sheariq-pwa-v4';
 const FILES_TO_CACHE = [
   'tally.html',
+  'farm-summary.html',
   'login.html',
   'styles.css',
   'tally.js',


### PR DESCRIPTION
## Summary
- Add dedicated Farm Summary page with auth check and link back to dashboard.
- Register a single click handler on the Farm Summary button that prevents default behavior and navigates to the new page.
- Cache the Farm Summary page in the service worker for offline support.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688e94f4bd78832186430cb3c12da530