### PR TITLE
chore: remove change PIN handler from dashboard

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -24,9 +24,6 @@ document.addEventListener('DOMContentLoaded', () => {
       window.location.href = 'farm-summary.html';
     });
 
-    document.getElementById('btnChangePin')?.addEventListener('click', () => {
-      window.location.href = 'change-pin.html';
-    });
 
     const btnViewSavedSessions = document.getElementById('btnViewSavedSessions');
     if (btnViewSavedSessions) {


### PR DESCRIPTION
## Summary
- remove obsolete change-pin navigation logic from dashboard

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f083f66c08321a6d45d4e7a64030c