### PR TITLE
Add contractor PIN change page

### DIFF
--- a/public/change-pin.html
+++ b/public/change-pin.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Change Contractor PIN</title>
+  <link rel="stylesheet" href="styles.css" />
+  <style>
+    body {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 20px;
+      background: #000;
+      color: #fff;
+      font-family: Arial, sans-serif;
+    }
+    form {
+      margin-top: 20px;
+      width: 100%;
+      max-width: 300px;
+      display: flex;
+      flex-direction: column;
+    }
+    form input {
+      margin: 6px 0;
+      padding: 8px;
+      text-align: center;
+    }
+    form button {
+      margin-top: 10px;
+    }
+    #message {
+      margin-top: 10px;
+    }
+  </style>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
+  <script src="firebase-init.js"></script>
+  <script src="firebase-auth-check.js"></script>
+</head>
+<body>
+  <div class="logo-container">
+    <img src="logo.png" alt="SHEΔR iQ logo" />
+    <h2>Change Contractor PIN</h2>
+  </div>
+  <form id="pinForm">
+    <label for="newPin">New PIN</label>
+    <input type="password" id="newPin" inputmode="numeric" pattern="\d{4}" maxlength="4" required />
+    <label for="confirmPin">Confirm New PIN</label>
+    <input type="password" id="confirmPin" inputmode="numeric" pattern="\d{4}" maxlength="4" required />
+    <button type="submit" class="main-button">Save PIN</button>
+  </form>
+  <div id="message" class="message"></div>
+  <script>
+    document.getElementById('pinForm').addEventListener('submit', function (e) {
+      e.preventDefault();
+      const newPin = document.getElementById('newPin').value.trim();
+      const confirmPin = document.getElementById('confirmPin').value.trim();
+      const messageEl = document.getElementById('message');
+      if (/^\d{4}$/.test(newPin) && newPin === confirmPin) {
+        localStorage.setItem('contractor_pin', newPin);
+        messageEl.textContent = 'PIN saved successfully.';
+        messageEl.style.color = '#0f0';
+      } else {
+        messageEl.textContent = 'PINs must match and be 4 digits.';
+        messageEl.style.color = '#ff4d4d';
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Change Contractor PIN page with form for entering and confirming new PIN
- validate PIN input, save to localStorage, and display success or error messages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f0c37efd483218f6fb7d267d73337