### PR TITLE
Use saved contractor PIN in tally unlock

### DIFF
--- a/public/tally.js
+++ b/public/tally.js
@@ -509,7 +509,8 @@ function unlockSession() {
 
 function promptForPinUnlock() {
     const pin = prompt('\uD83D\uDD10 Enter Contractor PIN to unlock editing:');
-    if (pin === '1234') {
+    const correctPIN = localStorage.getItem('contractor_pin') || '1234';
+    if (pin === correctPIN) {
         unlockSession();
     } else if (pin !== null) {
         alert('Incorrect PIN');


### PR DESCRIPTION
## Summary
- Use contractor PIN from `localStorage` when prompting to unlock session

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f14cbb6688321a022dd4609adb3d4