### PR TITLE
Show current contractor PIN in change-pin screen

### DIFF
--- a/public/change-pin.html
+++ b/public/change-pin.html
@@ -46,6 +46,8 @@
     <h2>Change Contractor PIN</h2>
   </div>
   <form id="pinForm">
+    <label for="current-pin">Current PIN</label>
+    <input type="text" id="current-pin" readonly />
     <label for="newPin">New PIN</label>
     <input type="password" id="newPin" inputmode="numeric" pattern="\d{4}" maxlength="4" required />
     <label for="confirmPin">Confirm New PIN</label>
@@ -54,6 +56,10 @@
   </form>
   <div id="message" class="message"></div>
   <script>
+    const currentPinInput = document.getElementById('current-pin');
+    const savedPin = localStorage.getItem('contractor_pin');
+    currentPinInput.value = savedPin ? savedPin : 'Not set';
+
     document.getElementById('pinForm').addEventListener('submit', function (e) {
       e.preventDefault();
       const newPin = document.getElementById('newPin').value.trim();


### PR DESCRIPTION
## Summary
- Display contractor's current PIN above the change form
- Auto-fill current PIN from `localStorage` or show 'Not set'

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f17ff28e4832188f67fd886b52f88