### PR TITLE
refactor: unify password toggle styling

### DIFF
--- a/public/change-pin.html
+++ b/public/change-pin.html
@@ -22,19 +22,11 @@
       display: flex;
       flex-direction: column;
     }
-    .pin-field {
-      display: flex;
-      align-items: center;
+    #pinForm .input-group {
       margin: 6px 0;
     }
-    .pin-field input {
-      flex: 1;
-      padding: 8px;
+    #pinForm .input-group input {
       text-align: center;
-    }
-    .pin-field button {
-      margin-left: 6px;
-      padding: 6px 8px;
     }
     form button.main-button {
       margin-top: 10px;
@@ -56,19 +48,19 @@
   </div>
   <form id="pinForm">
     <label for="current-pin">Current PIN</label>
-    <div class="pin-field">
+    <div class="input-group">
       <input type="password" id="current-pin" readonly />
-      <button type="button" class="toggle-btn" data-target="current-pin">Show 🔓</button>
+      <button type="button" class="toggle-password" data-target="current-pin">Show</button>
     </div>
     <label for="new-pin">New PIN</label>
-    <div class="pin-field">
+    <div class="input-group">
       <input type="password" id="new-pin" inputmode="numeric" pattern="\d{4}" maxlength="4" required />
-      <button type="button" class="toggle-btn" data-target="new-pin">Show 🔓</button>
+      <button type="button" class="toggle-password" data-target="new-pin">Show</button>
     </div>
     <label for="confirm-pin">Confirm New PIN</label>
-    <div class="pin-field">
+    <div class="input-group">
       <input type="password" id="confirm-pin" inputmode="numeric" pattern="\d{4}" maxlength="4" required />
-      <button type="button" class="toggle-btn" data-target="confirm-pin">Show 🔓</button>
+      <button type="button" class="toggle-password" data-target="confirm-pin">Show</button>
     </div>
     <button type="submit" class="main-button">Save PIN</button>
   </form>
@@ -98,15 +90,15 @@
     });
 
     // Toggle show/hide for PIN inputs
-    document.querySelectorAll('.toggle-btn').forEach((btn) => {
+    document.querySelectorAll('.toggle-password').forEach((btn) => {
       btn.addEventListener('click', () => {
         const target = document.getElementById(btn.dataset.target);
         if (target.type === 'password') {
           target.type = 'text';
-          btn.textContent = 'Hide 🔐';
+          btn.textContent = 'Hide';
         } else {
           target.type = 'password';
-          btn.textContent = 'Show 🔓';
+          btn.textContent = 'Show';
         }
       });
     });

--- a/public/login.html
+++ b/public/login.html
@@ -24,20 +24,6 @@
       margin: 6px 0;
     }
     #rememberMeLabel input { width: auto; margin-right: 6px; }
-    .password-container { position: relative; }
-    .password-container input { padding-right: 50px; }
-    .password-container button {
-      position: absolute;
-      top: 50%;
-      right: 10px;
-      transform: translateY(-50%);
-      background: #444;
-      border: none;
-      color: #fff;
-      padding: 4px 8px;
-      cursor: pointer;
-      z-index: 1;
-    }
     #login-error {
       color: #f44336;
       margin-top: 10px;
@@ -63,9 +49,9 @@
     <img id="loginLogo" src="src/assets/logo.png" alt="SHEAR iQ logo">
     <h2>Login</h2>
     <input type="email" id="email" placeholder="Email" required>
-    <div class="password-container">
+    <div class="input-group">
       <input type="password" id="password" placeholder="Password" required>
-      <button type="button" id="togglePassword">Show</button>
+      <button type="button" class="toggle-password" data-target="password">Show</button>
     </div>
     <label id="rememberMeLabel">
       <input type="checkbox" id="rememberMe">

--- a/public/login.js
+++ b/public/login.js
@@ -19,15 +19,16 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  const passwordInput = document.getElementById('password');
-  const togglePasswordBtn = document.getElementById('togglePassword');
-  if (togglePasswordBtn && passwordInput) {
-    togglePasswordBtn.addEventListener('click', () => {
-      const isPassword = passwordInput.type === 'password';
-      passwordInput.type = isPassword ? 'text' : 'password';
-      togglePasswordBtn.textContent = isPassword ? 'Hide' : 'Show';
+  document.querySelectorAll('.toggle-password').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const target = document.getElementById(btn.dataset.target);
+      if (target) {
+        const isPassword = target.type === 'password';
+        target.type = isPassword ? 'text' : 'password';
+        btn.textContent = isPassword ? 'Hide' : 'Show';
+      }
     });
-  }
+  });
 
   const loginForm = document.getElementById('loginForm');
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -19,6 +19,31 @@ label {
   font-size: 14px;
 }
 
+/* Shared input group styling for password/PIN fields */
+.input-group {
+  position: relative;
+}
+
+.input-group input {
+  width: 100%;
+  padding: 8px;
+  padding-right: 50px;
+  box-sizing: border-box;
+}
+
+.toggle-password {
+  position: absolute;
+  top: 50%;
+  right: 10px;
+  transform: translateY(-50%);
+  background: #444;
+  border: none;
+  color: #fff;
+  padding: 4px 8px;
+  cursor: pointer;
+  z-index: 1;
+}
+
 .meta-label {
   font-size: 18px;
   font-weight: 500;


### PR DESCRIPTION
## Summary
- centralize password/PIN visibility toggle styles and button classes
- update login and change-pin pages to use shared `.input-group` and `.toggle-password`
- apply generic JS handler for show/hide toggles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*


------
https://chatgpt.com/codex/tasks/task_e_688f1d5db4d48321916584f5df846ed3