### PR TITLE
Add return to dashboard button on change PIN page

### DIFF
--- a/public/change-pin.html
+++ b/public/change-pin.html
@@ -63,6 +63,7 @@
       <button type="button" class="toggle-password" data-target="confirm-pin">Show</button>
     </div>
     <button type="submit" class="main-button">Save PIN</button>
+    <button type="button" id="btnReturnToDashboard" class="main-button">Return to Dashboard</button>
   </form>
   <div id="message" class="message"></div>
   <script>
@@ -101,6 +102,10 @@
           btn.textContent = 'Show';
         }
       });
+    });
+
+    document.getElementById('btnReturnToDashboard').addEventListener('click', () => {
+      window.location.href = 'dashboard.html';
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add dedicated return button on change PIN page
- redirect to dashboard.html when tapped

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f221b4cbc8321800c3961a123da16