### PR TITLE
chore: remove farm summary button

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -43,7 +43,6 @@
     </div>
     <div id="buttonContainer">
       <button id="btnManageStaff" class="tab-button">Manage Staff</button>
-      <button id="btnFarmSummary" class="tab-button" type="button">Farm Summary</button>
       <button id="btnViewSavedSessions" class="tab-button">View Saved Sessions</button>
       <button id="btnReturnToActive" class="tab-button" style="display: none;"> Return to Active Session</button>
       <button id="btnStartNewDay" class="tab-button">Start New Day</button>


### PR DESCRIPTION
## Summary
- remove obsolete "Farm Summary" button from the dashboard

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f2a66bae88321bcbfbccfb362e2ca