### PR TITLE
feat: add farm summary dashboard button

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -22,10 +22,12 @@
       width: 100%;
       max-width: 400px;
     }
-    #buttonContainer .tab-button {
+    #buttonContainer .tab-button,
+    #buttonContainer .dashboard-button {
       margin: 6px 0;
     }
-    #buttonContainer .tab-button:hover {
+    #buttonContainer .tab-button:hover,
+    #buttonContainer .dashboard-button:hover {
       background: #555;
     }
   </style>
@@ -43,6 +45,7 @@
     </div>
     <div id="buttonContainer">
       <button id="btnManageStaff" class="tab-button">Manage Staff</button>
+      <button id="farm-summary-btn" class="dashboard-button">Farm Summary</button>
       <button id="btnViewSavedSessions" class="tab-button">View Saved Sessions</button>
       <button id="btnReturnToActive" class="tab-button" style="display: none;"> Return to Active Session</button>
       <button id="btnStartNewDay" class="tab-button">Start New Day</button>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -18,6 +18,13 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     }
 
+    const btnFarmSummary = document.getElementById('farm-summary-btn');
+    if (btnFarmSummary) {
+      btnFarmSummary.addEventListener('click', () => {
+        window.location.href = 'farm-summary.html';
+      });
+    }
+
     const btnViewSavedSessions = document.getElementById('btnViewSavedSessions');
     if (btnViewSavedSessions) {
       btnViewSavedSessions.addEventListener('click', () => {

--- a/public/styles.css
+++ b/public/styles.css
@@ -303,6 +303,7 @@ button {
   }
 
   .tab-button,
+  .dashboard-button,
   .toggle-button,
   .section h2,
   label {
@@ -329,7 +330,8 @@ button {
   display: flex;
   margin-bottom: 10px;
 }
-.tab-button {
+.tab-button,
+.dashboard-button {
   padding: 12px 16px;
   background: #444;
   color: #fff;


### PR DESCRIPTION
## Summary
- add Farm Summary button to dashboard
- style new button to match existing layout
- wire Farm Summary button to farm summary page

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f2de9d440832199dc0463a6f4aaa9