### PR TITLE
Stop dashboard auto-redirect to tally page

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -31,7 +31,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     const btnReturnToActive = document.getElementById('btnReturnToActive');
-    const activeSession = localStorage.getItem('tally_session');
+    const activeSession = localStorage.getItem('active_session');
+
+    // Only reveal the "Return to Active Session" button when an active session exists.
+    // Automatic redirection to tally.html has been removed so contractors choose
+    // when to resume a session.
     if (btnReturnToActive && activeSession) {
       btnReturnToActive.style.display = 'block';
       btnReturnToActive.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Prevent dashboard from auto-redirecting when an active session exists
- Show "Return to Active Session" button based on `active_session` in localStorage

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f328e29d48321a2a00c06845a5b31