### PR TITLE
Add debug log for Farm Summary button

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -20,6 +20,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const btnFarmSummary = document.getElementById('farm-summary-btn');
     btnFarmSummary?.addEventListener('click', () => {
+      console.log('Farm Summary button clicked');
       window.location.href = 'farm-summary.html';
     });
 


### PR DESCRIPTION
## Summary
- Add console log when Farm Summary button is clicked for easier debugging
- Verified no auto-redirect to `tally.html` remains in dashboard logic

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f3535ada883218190150e5825e606