### PR TITLE
Unregister service workers on dashboard

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1,5 +1,13 @@
 import { handleLogout } from './auth.js';
 
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.getRegistrations().then(function(registrations) {
+    for (let registration of registrations) {
+      registration.unregister();
+    }
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   firebase.auth().onAuthStateChanged(user => {
     if (!user) {


### PR DESCRIPTION
## Summary
- Clear out any active service workers on dashboard load to avoid stale redirects

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f3bb8d7448321a06747d41d0b7775