### PR TITLE
style: align show password button with input

### DIFF
--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -56,25 +56,31 @@
       background: #555;
     }
     .password-container {
-      position: relative;
+      display: flex;
       width: 100%;
     }
     .password-container input {
-      padding-right: 50px;
-      width: 100%;
+      flex: 1;
+      width: auto;
+      min-width: 0;
+      padding: 8px;
+      background: #222;
+      color: #fff;
+      border: 1px solid #555;
+      border-right: none;
       box-sizing: border-box;
     }
     .password-container button {
-      position: absolute;
-      top: 50%;
-      right: 10px;
-      transform: translateY(-50%);
+      padding: 8px 12px;
       background: #444;
-      border: none;
+      border: 1px solid #555;
+      border-left: none;
       color: #fff;
-      padding: 4px 8px;
       cursor: pointer;
-      z-index: 1;
+      flex-shrink: 0;
+    }
+    .password-container button:hover {
+      background: #555;
     }
     #staffSummary {
       margin-top: 20px;
@@ -372,7 +378,7 @@
         <label for="staff-password">New Password</label>
         <div class="password-container">
           <input type="password" id="staff-password" placeholder="New Password" required>
-          <button type="button" id="toggleStaffPassword">Show</button>
+            <button type="button" id="toggleStaffPassword" aria-label="Show password">Show</button>
         </div>
       </div>
       <div class="form-group">


### PR DESCRIPTION
## Summary
- align new password input and show toggle side-by-side for staff creation
- add accessible label for password toggle button

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6891e11b95888321ae3bef587bb1d59c