### PR TITLE
style: embed show password button

### DIFF
--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -55,31 +55,33 @@
     form button:hover {
       background: #555;
     }
-    .password-container {
-      display: flex;
+    .password-wrapper {
+      position: relative;
       width: 100%;
     }
-    .password-container input {
-      flex: 1;
-      width: auto;
-      min-width: 0;
+    .password-wrapper input {
+      width: 100%;
       padding: 8px;
+      padding-right: 60px;
       background: #222;
       color: #fff;
       border: 1px solid #555;
-      border-right: none;
+      border-radius: 4px;
       box-sizing: border-box;
     }
-    .password-container button {
-      padding: 8px 12px;
+    .password-wrapper button {
+      position: absolute;
+      top: 50%;
+      right: 10px;
+      transform: translateY(-50%);
       background: #444;
-      border: 1px solid #555;
-      border-left: none;
       color: #fff;
+      border: none;
+      padding: 4px 8px;
       cursor: pointer;
-      flex-shrink: 0;
+      border-radius: 4px;
     }
-    .password-container button:hover {
+    .password-wrapper button:hover {
       background: #555;
     }
     #staffSummary {
@@ -376,11 +378,9 @@
       </div>
       <div class="form-group">
         <label for="staff-password">New Password</label>
-        <div style="position: relative;">
-          <input type="password" id="staff-password" placeholder="New Password" required
-                 style="width: 100%; padding: 8px; padding-right: 50px; box-sizing: border-box;">
-          <button type="button" id="toggleStaffPassword" aria-label="Show password"
-                  style="position: absolute; top: 50%; right: 10px; transform: translateY(-50%); background: #444; border: none; color: #fff; padding: 4px 8px; cursor: pointer; font-size: 14px; z-index: 1;">Show</button>
+        <div class="password-wrapper">
+          <input type="password" id="staff-password" placeholder="New Password" required>
+          <button type="button" id="toggleStaffPassword" aria-label="Show password">👁 Show</button>
         </div>
       </div>
       <div class="form-group">

--- a/public/manage-staff.js
+++ b/public/manage-staff.js
@@ -59,7 +59,10 @@ function togglePasswordVisibility(inputEl, btn) {
   if (!inputEl) return;
   const isPassword = inputEl.type === 'password';
   inputEl.type = isPassword ? 'text' : 'password';
-  if (btn) btn.textContent = isPassword ? 'Hide' : 'Show';
+  if (btn) {
+    btn.innerHTML = `👁 ${isPassword ? 'Hide' : 'Show'}`;
+    btn.setAttribute('aria-label', isPassword ? 'Hide password' : 'Show password');
+  }
 }
 
 async function loadStaffList(contractorId) {


### PR DESCRIPTION
## Summary
- restyle password field by wrapping input and toggle button in a relative container
- allow toggling between 👁 Show and 👁 Hide inside the password input

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6891ea982c188321aa5a40f2b3e6aa9c