### PR TITLE
Remove password toggle from manage staff form

### DIFF
--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -55,35 +55,6 @@
     form button:hover {
       background: #555;
     }
-    .password-container {
-      position: relative;
-      width: 100%;
-    }
-
-    .password-input {
-      width: 100%;
-      padding-right: 70px;
-      height: 40px;
-      font-size: 16px;
-      border: 1px solid #ccc;
-      border-radius: 6px;
-      box-sizing: border-box;
-    }
-
-    .toggle-password-btn {
-      position: absolute;
-      right: 8px;
-      top: 50%;
-      transform: translateY(-50%);
-      height: 28px;
-      padding: 0 12px;
-      background-color: #444;
-      color: white;
-      border: none;
-      border-radius: 4px;
-      font-size: 14px;
-      cursor: pointer;
-    }
     #staffSummary {
       margin-top: 20px;
       font-size: 18px;
@@ -378,10 +349,7 @@
       </div>
       <div class="form-group">
         <label for="new-password">New Password</label>
-        <div class="password-container">
-          <input id="new-password" type="password" class="password-input" placeholder="New Password" required>
-          <button type="button" class="toggle-password-btn">Show</button>
-        </div>
+        <input id="new-password" type="password" placeholder="Enter password" required>
       </div>
       <div class="form-group">
         <select id="staffRoleSelect">

--- a/public/manage-staff.js
+++ b/public/manage-staff.js
@@ -55,16 +55,6 @@ function showConfirm(message) {
   });
 }
 
-function togglePasswordVisibility(inputId, button) {
-  const input = document.getElementById(inputId);
-  if (input.type === 'password') {
-    input.type = 'text';
-    button.textContent = 'Hide';
-  } else {
-    input.type = 'password';
-    button.textContent = 'Show';
-  }
-}
 
 async function loadStaffList(contractorId) {
   const tbody = document.querySelector('#staffTable tbody');
@@ -244,12 +234,6 @@ async function restoreStaff(btn) {
         deletedStaffHeader.classList.toggle('expanded', !collapsed);
         localStorage.setItem(DELETED_STAFF_STATE_KEY, collapsed ? 'collapsed' : 'expanded');
       });
-    }
-    const togglePasswordBtn = document.querySelector('.toggle-password-btn');
-    if (togglePasswordBtn) {
-      togglePasswordBtn.addEventListener('click', () =>
-        togglePasswordVisibility('new-password', togglePasswordBtn)
-      );
     }
     if (overlay) overlay.style.display = 'flex';
     onAuthStateChanged(auth, async user => {


### PR DESCRIPTION
## Summary
- replace New Password field with a simple password input
- drop unused togglePasswordVisibility helper and related styles

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6891f18a07a88321bc3bdb166bb45f48