### PR TITLE
Make new password input visible

### DIFF
--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -349,7 +349,7 @@
       </div>
       <div class="form-group">
         <label for="new-password">New Password</label>
-        <input id="new-password" type="password" placeholder="Enter password" required>
+        <input id="new-password" type="text" placeholder="Enter password" required>
       </div>
       <div class="form-group">
         <select id="staffRoleSelect">


### PR DESCRIPTION
## Summary
- show new password text by changing input type to `text`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6891f5155db0832188a5b36ed8e729dc