### PR TITLE
fix: ensure tooltips always visible

### DIFF
--- a/public/tally.html
+++ b/public/tally.html
@@ -20,7 +20,25 @@
     <link rel="apple-touch-icon" href="icon-192.png" />
 
     <!-- Theme Color -->
-    <meta name="theme-color" content="#000000" /> 
+    <meta name="theme-color" content="#000000" />
+  <!-- Tooltip visibility fix -->
+  <style id="tt-tooltip-fix">
+    #tt-root {
+      position: fixed;
+      max-width: 280px;
+      pointer-events: none;
+      z-index: 2147483647; /* on top of everything */
+    }
+    .tt-hidden {
+      display: none;
+      opacity: 0;
+    }
+    .tt-show {
+      display: block;
+      opacity: 1;
+      transform: translateY(0);
+    }
+  </style>
 </head>
 <body>
 
@@ -476,7 +494,7 @@ document.addEventListener('DOMContentLoaded', () => {
       color: #fff;
       border-radius: 10px;
       box-shadow: 0 10px 30px rgba(0,0,0,0.35);
-      z-index: 900;
+      z-index: 2147483647;
       font-size: 14px;
       line-height: 1.35;
       pointer-events: none;
@@ -498,10 +516,14 @@ document.addEventListener('DOMContentLoaded', () => {
       border-radius: 8px;
     }
     .tt-show {
+      display: block;
       opacity: 1;
       transform: translateY(0);
     }
-    .tt-hidden { display: none; }
+    .tt-hidden {
+      display: none;
+      opacity: 0;
+    }
     @media (prefers-reduced-motion: reduce) {
       #tt-root { transition: none; }
     }

--- a/public/tally.js
+++ b/public/tally.js
@@ -2590,6 +2590,14 @@ function initTallyTooltips() {
     document.body.appendChild(tt);
   }
 
+  // Ensure tooltip is a direct child of <body> so it can't be clipped
+  (function ensureTooltipParent() {
+    const ttRoot = document.getElementById('tt-root');
+    if (ttRoot && ttRoot.parentElement !== document.body) {
+      document.body.appendChild(ttRoot);
+    }
+  })();
+
   let stored = localStorage.getItem('tooltips_enabled');
   if (stored === null) {
     localStorage.setItem('tooltips_enabled', 'true');
@@ -2680,7 +2688,11 @@ function initTallyTooltips() {
   }
 
   function showTooltip(target, text) {
-    if (!text) return;
+    // Do not show empty tooltips
+    if (!text || !String(text).trim()) {
+      hideTooltip();
+      return;
+    }
     tt.textContent = text;
     tt.setAttribute('aria-hidden', 'false');
     tt.classList.remove('tt-hidden');
@@ -2920,6 +2932,13 @@ function initTallyTooltips() {
 }
 
 window.initTallyTooltips = initTallyTooltips;
+
+// Fallback initialisation in case Firebase auth never resolves (offline)
+window.addEventListener('DOMContentLoaded', () => {
+  if (!window.__tallyTooltipsInitialized && typeof initTallyTooltips === 'function') {
+    try { initTallyTooltips(); } catch (e) { console.warn('Tooltip init fallback:', e); }
+  }
+}, { once: true });
 
 async function setup() {
   const overlay = document.getElementById('loading-overlay');


### PR DESCRIPTION
## Summary
- enforce tooltip visibility with top-level z-index and consistent show/hide classes
- keep tooltip root attached to `<body>` and guard against empty tooltip text
- add fallback tooltip initialization when Firebase auth fails to resolve

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68991a61ccd48321a73bb024a953e7ab