### PR TITLE
Ensure tooltip visibility override for tally tooltips

### DIFF
--- a/public/tally.html
+++ b/public/tally.html
@@ -39,6 +39,25 @@
       transform: translateY(0);
     }
   </style>
+  <style id="tt-tooltip-override">
+    #tt-root {
+      position: fixed;
+      max-width: 280px;
+      pointer-events: none;
+      z-index: 2147483647;
+    }
+    #tt-root.tt-hidden,
+    #tt-root[aria-hidden="true"] {
+      display: none !important;
+      opacity: 0 !important;
+    }
+    #tt-root.tt-show,
+    #tt-root[aria-hidden="false"] {
+      display: block !important;
+      opacity: 1 !important;
+      transform: translateY(0) !important;
+    }
+  </style>
 </head>
 <body>
 

--- a/public/tally.js
+++ b/public/tally.js
@@ -2691,28 +2691,26 @@ function initTallyTooltips() {
   }
 
   function showTooltip(target, text) {
-    // Do not show empty tooltips
-    if (!text || !String(text).trim()) {
-      hideTooltip();
-      return;
-    }
-    tt.textContent = text;
+    if (!text || !String(text).trim()) { hideTooltip(); return; }
+    const tt = document.getElementById('tt-root');
     tt.setAttribute('aria-hidden', 'false');
     tt.classList.remove('tt-hidden');
     tt.classList.add('tt-show');
+    tt.textContent = text;
     target.setAttribute('aria-describedby', 'tt-root');
     currentTarget = target;
     positionTooltip(target);
   }
 
   function hideTooltip() {
+    const tt = document.getElementById('tt-root');
+    tt.setAttribute('aria-hidden', 'true');
+    tt.classList.remove('tt-show');
+    tt.classList.add('tt-hidden');
     if (currentTarget) {
       currentTarget.removeAttribute('aria-describedby');
       currentTarget = null;
     }
-    tt.classList.remove('tt-show');
-    tt.classList.add('tt-hidden');
-    tt.setAttribute('aria-hidden', 'true');
   }
 
   function highlight(el) {


### PR DESCRIPTION
## Summary
- Add final CSS override to enforce tooltip visibility and z-index
- Update showTooltip and hideTooltip to toggle classes and aria-hidden reliably

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689924ec33748321a58a65fd384d22e3