### PR TITLE
Switch tally page to Firestore compat

### DIFF
--- a/public/export.js
+++ b/public/export.js
@@ -1,6 +1,6 @@
-import { collectExportData, buildExportRows, buildStationSummary, isNineHourDay, formatHoursWorked, parseHoursWorked } from './tally.js';
+// Functions from tally.js are loaded globally; no module imports needed
 
-export function exportTableToCSV(tableId, baseName = 'table') {
+function exportTableToCSV(tableId, baseName = 'table') {
     const table = document.getElementById(tableId);
     if (!table) return;
     const rows = Array.from(table.querySelectorAll('tr')).map(tr =>
@@ -24,7 +24,7 @@ export function exportTableToCSV(tableId, baseName = 'table') {
 }
 window.exportTableToCSV = exportTableToCSV;
 
-export function exportFarmSummaryCSV() {
+function exportFarmSummaryCSV() {
     const tables = [
         ['stationShearerTable', 'Shearer Summary'],
         ['stationStaffTable', 'Shed Staff'],
@@ -67,7 +67,7 @@ export function exportFarmSummaryCSV() {
 }
 window.exportFarmSummaryCSV = exportFarmSummaryCSV;
 
-export function exportDailySummaryCSV() {
+function exportDailySummaryCSV() {
     const data = collectExportData();
 
     const optionSet = new Set(Array.from(document.querySelectorAll('#sheepTypes option')).map(o => o.value));
@@ -283,9 +283,9 @@ function loadPreviousSession() {
         if (window.promptForPinUnlock) window.promptForPinUnlock();
     }
 }
+window.exportDailySummaryCSV = exportDailySummaryCSV;
 
-
-export function exportCSV() {
+function exportCSV() {
     const data = collectExportData();
     const { rows } = buildExportRows(data);
     const csv = rows.map(r => r.map(v => `"${String(v ?? '').replace(/"/g,'""')}"`).join(',')).join('\r\n');
@@ -305,7 +305,7 @@ export function exportCSV() {
     URL.revokeObjectURL(url);
 }
 
-export function exportDailySummaryExcel() {
+function exportDailySummaryExcel() {
     if (typeof XLSX === 'undefined') {
         alert('Excel export not available');
         return;
@@ -444,7 +444,7 @@ export function exportDailySummaryExcel() {
     XLSX.writeFile(wb, fileName);
 }
 
-export function showExportPrompt() {
+function showExportPrompt() {
     const useExcel = window.confirm('Export as Excel (.xlsx)? Click Cancel for CSV.');
     if (useExcel) exportDailySummaryExcel();
     else exportDailySummaryCSV();

--- a/public/tally.html
+++ b/public/tally.html
@@ -8,8 +8,8 @@
 <title>SHEAR iQ Tally Processor</title>
 <link rel="stylesheet" href="styles.css">
   <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
   <script src="firebase-init.js"></script>
   <!-- PWA Manifest -->
     <link rel="manifest" href="manifest.json" />
@@ -230,9 +230,9 @@
 
 <script src="xlsx.full.min.js"></script>
 <script type="module" src="auth.js"></script>
-<script type="module" src="tally.js"></script>
-<script type="module" src="export.js"></script>
-<script type="module" src="serviceworker.js"></script>
+<script src="tally.js"></script>
+<script src="export.js"></script>
+<script src="serviceworker.js"></script>
 
   </div> <!-- tallySheetView -->
 
@@ -490,8 +490,7 @@ document.addEventListener('DOMContentLoaded', function () {
   </div>
 </div>
 
-<script type="module">
-import { buildStationSummary, clearStationSummaryView } from './tally.js';
+<script>
 window.clearStationSummaryView = clearStationSummaryView;
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- Add Firestore compat script and load `tally.js` without modules so the tally page works with non‑module scripts
- Replace modular Firestore tour helpers with `firebase.firestore()` calls and wire start/skip buttons to mark the tour as seen
- Trigger the tour check after auth so the welcome modal appears only for first‑time users
- Remove module import from export utilities to rely on globals from `tally.js`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6899353d0a448321ae6482827e299e81