### PR TITLE
Add controls to disable tooltips and guided tour

### DIFF
--- a/public/tally.html
+++ b/public/tally.html
@@ -580,6 +580,8 @@ document.addEventListener('DOMContentLoaded', () => {
       font-size: 14px;
       z-index: 900;
       display: none;
+      min-width: 180px;
+      max-width: calc(100vw - 8px);
     }
     #tt-help-menu button,
     #tt-help-menu label {
@@ -590,9 +592,24 @@ document.addEventListener('DOMContentLoaded', () => {
       margin: 4px 0;
       text-align: left;
       font-size: 14px;
+      padding: 8px 12px;
+      min-height: 40px;
     }
     #tt-help-menu input[type="checkbox"] {
-      margin-right: 4px;
+      margin-right: 6px;
+    }
+    #tt-disabled-toast {
+      position: fixed;
+      bottom: 20px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: rgba(20,20,20,0.95);
+      color: #fff;
+      padding: 8px 12px;
+      border-radius: 6px;
+      font-size: 14px;
+      z-index: 9999;
+      display: none;
     }
   </style>
 


### PR DESCRIPTION
## Summary
- Add persistent flags to enable or disable tooltips and the guided tour.
- Provide a help menu with checkboxes and buttons to toggle features and reset tour state.
- Guard tooltip/guided logic with these flags and expose testing hooks.

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check public/tally.js`


------
https://chatgpt.com/codex/tasks/task_e_689962e22d488321b00c676828c57824