### PR TITLE
feat: add help menu to tally processor

### DIFF
--- a/public/tally.html
+++ b/public/tally.html
@@ -236,7 +236,7 @@
 
 <script src="xlsx.full.min.js"></script>
 <script type="module" src="auth.js"></script>
-<script src="tally.js"></script>
+<script src="/tally.js?v=help-menu-1"></script>
 <script src="export.js"></script>
 <script src="serviceworker.js"></script>
 
@@ -517,13 +517,13 @@ document.addEventListener('DOMContentLoaded', () => {
   <div>Authenticating… Please wait</div>
 </div>
 
-<button id="tour-help-btn" aria-label="Help">?</button>
+<button id="help-btn" class="icon-btn" aria-label="Help">?</button>
 <div id="tt-help-menu" class="tt-hidden" aria-hidden="true"></div>
 
 <div id="tt-root" class="tt-hidden" role="tooltip" aria-hidden="true" aria-live="polite"></div>
 
 <style>
-  #tour-help-btn {
+  #help-btn {
     position: fixed; top: 12px; right: 12px; z-index: 9999;
     width: 36px; height: 36px; border-radius: 9999px;
   }


### PR DESCRIPTION
## Summary
- add stable help button and cache bust tally script
- implement global help menu with tooltips and guided tour toggles
- wire help button and Alt+H shortcut to open menu or start tour

## Testing
- `node --check public/tally.js`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689975ee1c288321b877e33f45ddec03