### PR TITLE
Support 600ms long-press for Help menu

### DIFF
--- a/public/tally.html
+++ b/public/tally.html
@@ -236,7 +236,7 @@
 
 <script src="xlsx.full.min.js"></script>
 <script type="module" src="auth.js"></script>
-<script src="/tally.js?v=help-menu-2"></script>
+<script src="/tally.js?v=help-menu-longpress-1"></script>
 <script src="export.js"></script>
 <script src="serviceworker.js"></script>
 


### PR DESCRIPTION
## Summary
- allow long-press (600ms) on Help button to open the Help menu without starting tour
- cache-bust tally script so mobile devices load updated JavaScript

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689989a6ccc48321856fc0b29792b1d1