### PR TITLE
Improve iOS long-press handling for Help menu

### DIFF
--- a/public/tally.html
+++ b/public/tally.html
@@ -84,6 +84,14 @@
   .tw-btn-ghost { background: #222; color: #eee; }
   .tw-btn:focus { outline: 2px solid #5aa0ff; outline-offset: 2px; }
 </style>
+<style>
+  #help-btn, #tour-help-btn {
+    touch-action: none;              /* reduce scroll/pan interference */
+    -webkit-touch-callout: none;     /* stop iOS text callout */
+    -webkit-user-select: none;
+    user-select: none;
+  }
+</style>
 </head>
 <body>
 
@@ -236,7 +244,7 @@
 
 <script src="xlsx.full.min.js"></script>
 <script type="module" src="auth.js"></script>
-<script src="/tally.js?v=help-menu-longpress-1"></script>
+ <script src="/tally.js?v=help-menu-longpress-2"></script>
 <script src="export.js"></script>
 <script src="serviceworker.js"></script>
 


### PR DESCRIPTION
## Summary
- replace long-press handler with jitter-tolerant pointer/touch implementation
- disable iOS touch callout on help buttons and bust script cache

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68998d5ec6b08321875b63ef6433b5cd