### PR TITLE
feat: add top 5 shearers widget

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -44,6 +44,60 @@
       <h2 id="dashboard-heading">Contractor Dashboard</h2>
       <p id="dashboard-subheading"></p>
     </div>
+    <!-- BEGIN: Top 5 Shearers Widget -->
+    <section id="top5-shearers" class="dash-card">
+      <header class="dash-card__header">
+        <h2 class="dash-card__title">Top 5 Shearers</h2>
+        <div class="dash-card__controls">
+          <!-- Work type tabs -->
+          <div class="siq-segmented" id="worktype-tabs">
+            <button type="button" data-worktype="shorn" class="siq-segmented__btn is-active">Shorn</button>
+            <button type="button" data-worktype="crutched" class="siq-segmented__btn">Crutched</button>
+          </div>
+          <!-- View selector -->
+          <div class="view-select">
+            <label for="shearers-view">View</label>
+            <select id="shearers-view">
+              <option value="12m" selected>12M Rolling</option>
+              <option value="all">All‑Time</option>
+            </select>
+            <select id="shearers-year" class="year-select" aria-label="Specific year" hidden></select>
+          </div>
+          <button type="button" id="shearers-viewall" class="siq-link-button">View Full List</button>
+        </div>
+      </header>
+
+      <div id="top5-shearers-list" class="siq-leaderboard">
+        <!-- JS renders 5 rows with bars -->
+      </div>
+    </section>
+
+    <!-- Full list modal -->
+    <div id="shearers-modal" class="siq-modal" aria-hidden="true">
+      <div class="siq-modal__backdrop" data-close-modal></div>
+      <div class="siq-modal__panel">
+        <header class="siq-modal__header">
+          <h3>All Shearers — Rankings</h3>
+          <button class="siq-modal__close" data-close-modal aria-label="Close">&times;</button>
+        </header>
+        <div class="siq-modal__body">
+          <div class="siq-table-scroll">
+            <table class="siq-rank-table" id="shearers-full-table">
+              <thead>
+                <tr>
+                  <th>#</th>
+                  <th>Shearer</th>
+                  <th>Total Sheep</th>
+                  <th>% of Total</th>
+                </tr>
+              </thead>
+              <tbody><!-- JS fills --></tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- END: Top 5 Shearers Widget -->
     <div id="buttonContainer">
       <button id="btnManageStaff" class="tab-button">Manage Staff</button>
       <button id="farm-summary-btn" class="dashboard-button">Farm Summary</button>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -8,6 +8,353 @@ if ('serviceWorker' in navigator) {
   });
 }
 
+function initTop5ShearersWidget() {
+  (function () {
+    const flag = localStorage.getItem('dash_top5_shearers_enabled');
+    const rootEl = document.getElementById('top5-shearers');
+    if (flag === 'false' || !rootEl) {
+      if (rootEl) rootEl.remove();
+      return;
+    }
+
+    const contractorId = localStorage.getItem('contractor_id');
+    if (!contractorId) {
+      console.warn('[Top5Shearers] Missing contractor_id');
+      rootEl.innerHTML = '<p class="siq-inline-error">Data unavailable</p>';
+      return;
+    }
+
+    const listEl = rootEl.querySelector('#top5-shearers-list');
+    const viewSel = rootEl.querySelector('#shearers-view');
+    const yearSel = rootEl.querySelector('#shearers-year');
+    const viewAllBtn = rootEl.querySelector('#shearers-viewall');
+    const tabs = rootEl.querySelector('#worktype-tabs');
+    const modal = document.getElementById('shearers-modal');
+    const modalBodyTbody = document.querySelector('#shearers-full-table tbody');
+    if (!listEl || !viewSel || !yearSel || !viewAllBtn || !tabs || !modal || !modalBodyTbody) {
+      console.warn('[Top5Shearers] Missing elements');
+      return;
+    }
+
+    function isCrutchedType(sheepType) {
+      if (!sheepType) return false;
+      const s = String(sheepType).toLowerCase();
+      return s.includes('crutch');
+    }
+
+    function getDateRange(mode, year) {
+      const today = new Date();
+      if (mode === '12m') {
+        const end = today;
+        const start = new Date();
+        start.setDate(start.getDate() - 365);
+        return { start, end };
+      }
+      if (mode === 'year' && year) {
+        const start = new Date(Number(year), 0, 1, 0, 0, 0);
+        const end = new Date(Number(year), 11, 31, 23, 59, 59);
+        return { start, end };
+      }
+      return { start: null, end: null };
+    }
+
+    function sessionDateToJS(d) {
+      if (!d) return null;
+      if (typeof d === 'object' && d.toDate) return d.toDate();
+      const dt = new Date(d);
+      return isNaN(dt.getTime()) ? null : dt;
+    }
+
+    function* iterateTalliesFromSession(sessionDoc) {
+      const s = sessionDoc.data ? sessionDoc.data() : sessionDoc;
+      const sessionDate = sessionDateToJS(s.date || s.sessionDate || s.createdAt);
+
+      if (Array.isArray(s.tallies)) {
+        for (const t of s.tallies) {
+          yield {
+            shearerName: t.shearerName || t.shearer || t.name,
+            count: Number(t.count || t.tally || 0),
+            sheepType: t.sheepType || t.type,
+            date: sessionDate
+          };
+        }
+        return;
+      }
+
+      if (Array.isArray(s.shearers)) {
+        for (const sh of s.shearers) {
+          const shearerName = sh.name || sh.shearerName || sh.displayName || sh.id || 'Unknown';
+          const runs = sh.runs || sh.tallies || sh.entries || [];
+          for (const r of (runs || [])) {
+            yield {
+              shearerName,
+              count: Number(r.count || r.tally || 0),
+              sheepType: r.sheepType || r.type,
+              date: sessionDate
+            };
+          }
+          if (typeof sh.total === 'number') {
+            yield {
+              shearerName,
+              count: Number(sh.total),
+              sheepType: sh.sheepType || null,
+              date: sessionDate
+            };
+          }
+        }
+        return;
+      }
+
+      if (s.shearerTallies && typeof s.shearerTallies === 'object') {
+        for (const [shearerName, entries] of Object.entries(s.shearerTallies)) {
+          for (const e of (entries || [])) {
+            yield {
+              shearerName,
+              count: Number(e.count || e.tally || 0),
+              sheepType: e.sheepType || e.type,
+              date: sessionDate
+            };
+          }
+        }
+      }
+    }
+
+    function aggregateShearers(sessions, mode, year, workType) {
+      const { start, end } = getDateRange(mode, year);
+      const wantCrutched = (workType === 'crutched');
+      const totals = new Map();
+      let grandTotal = 0;
+      for (const doc of sessions) {
+        for (const t of iterateTalliesFromSession(doc)) {
+          if (!t || !t.shearerName) continue;
+          if (!t.date) continue;
+          if (start && t.date < start) continue;
+          if (end && t.date > end) continue;
+          const isCrutch = isCrutchedType(t.sheepType);
+          if (wantCrutched && !isCrutch) continue;
+          if (!wantCrutched && isCrutch) continue;
+          const prev = totals.get(t.shearerName) || 0;
+          const next = prev + (t.count || 0);
+          totals.set(t.shearerName, next);
+          grandTotal += (t.count || 0);
+        }
+      }
+      const rows = Array.from(totals.entries())
+        .map(([name, total]) => ({ name, total }))
+        .sort((a, b) => b.total - a.total);
+      return { rows, grandTotal };
+    }
+
+    function renderTop5Shearers(rows, container) {
+      const top5 = rows.slice(0, 5);
+      const max = Math.max(1, ...top5.map(r => r.total));
+      container.innerHTML = top5.map((r, idx) => {
+        const pct = Math.round((r.total / max) * 100);
+        return `
+      <div class="siq-lb-row">
+        <div class="siq-lb-rank">${idx + 1}</div>
+        <div class="siq-lb-bar">
+          <div class="siq-lb-fill" style="width:${pct}%;"></div>
+          <div class="siq-lb-name" title="${r.name}">${r.name}</div>
+        </div>
+        <div class="siq-lb-value">${r.total.toLocaleString()}</div>
+      </div>
+    `;
+      }).join('');
+    }
+
+    function renderFullShearers(rows, grandTotal, tableBody) {
+      tableBody.innerHTML = rows.map((r, idx) => {
+        const pct = grandTotal ? ((r.total / grandTotal) * 100) : 0;
+        return `
+      <tr>
+        <td>${idx + 1}</td>
+        <td>${r.name}</td>
+        <td>${r.total.toLocaleString()}</td>
+        <td>${pct.toFixed(1)}%</td>
+      </tr>
+    `;
+      }).join('');
+    }
+
+    function deriveYearsFromSessions(sessions) {
+      const years = new Set();
+      for (const doc of sessions) {
+        const s = doc.data ? doc.data() : doc;
+        const dt = sessionDateToJS(s.date || s.sessionDate || s.createdAt);
+        if (dt) years.add(dt.getFullYear());
+      }
+      const arr = Array.from(years).sort((a, b) => b - a);
+      const current = (new Date()).getFullYear();
+      if (!arr.includes(current)) arr.unshift(current);
+      return arr;
+    }
+
+    let modalKeyHandler = null;
+    let lastFocused = null;
+    function trapFocus(e) {
+      if (e.key === 'Escape') {
+        closeModal('shearers-modal');
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      const focusable = modal.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+      if (!focusable.length) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+
+    function openModal(id) {
+      if (!rootEl) return;
+      const m = document.getElementById(id);
+      if (!m) return;
+      lastFocused = document.activeElement;
+      m.setAttribute('aria-hidden', 'false');
+      modalKeyHandler = trapFocus;
+      m.addEventListener('keydown', modalKeyHandler);
+      const focusable = m.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+      if (focusable.length) focusable[0].focus();
+    }
+
+    function closeModal(id) {
+      const m = document.getElementById(id);
+      if (!m) return;
+      m.setAttribute('aria-hidden', 'true');
+      if (modalKeyHandler) {
+        m.removeEventListener('keydown', modalKeyHandler);
+        modalKeyHandler = null;
+      }
+      if (lastFocused) lastFocused.focus();
+    }
+
+    let shearersUnsub = null;
+    let colRef = null;
+    let cachedSessions = [];
+    let cachedRows = [];
+    let cachedGrandTotal = 0;
+    let renderPending = false;
+
+    function renderFromCache() {
+      if (!cachedSessions.length) {
+        listEl.innerHTML = '';
+        modalBodyTbody.innerHTML = '';
+        return;
+      }
+      const workType = tabs.querySelector('.siq-segmented__btn.is-active')?.dataset.worktype || 'shorn';
+      const mode = (viewSel.value === 'year') ? 'year' : (viewSel.value || '12m');
+      const year = (mode === 'year') ? (yearSel.value || new Date().getFullYear()) : null;
+      const { rows, grandTotal } = aggregateShearers(cachedSessions, mode, year, workType);
+      cachedRows = rows;
+      cachedGrandTotal = grandTotal;
+      renderTop5Shearers(rows, listEl);
+      renderFullShearers(rows, grandTotal, modalBodyTbody);
+    }
+
+    function scheduleRender() {
+      if (renderPending) return;
+      renderPending = true;
+      requestAnimationFrame(() => {
+        renderPending = false;
+        renderFromCache();
+      });
+    }
+
+    tabs.addEventListener('click', e => {
+      if (!rootEl) return;
+      const btn = e.target.closest('.siq-segmented__btn');
+      if (!btn) return;
+      tabs.querySelectorAll('.siq-segmented__btn').forEach(b => b.classList.remove('is-active'));
+      btn.classList.add('is-active');
+      scheduleRender();
+    });
+
+    viewSel.addEventListener('change', () => {
+      if (!rootEl) return;
+      const v = viewSel.value;
+      if (v === 'all' || v === '12m') {
+        yearSel.hidden = true;
+      }
+      scheduleRender();
+    });
+
+    yearSel.addEventListener('change', () => {
+      if (!rootEl) return;
+      scheduleRender();
+    });
+
+    yearSel.addEventListener('focus', () => {
+      if (!rootEl) return;
+      if (viewSel.value !== 'year') {
+        if (![...viewSel.options].some(o => o.value === 'year')) {
+          const opt = document.createElement('option');
+          opt.value = 'year';
+          opt.textContent = 'Specific Year';
+          viewSel.appendChild(opt);
+        }
+        viewSel.value = 'year';
+        yearSel.hidden = false;
+      }
+    });
+
+    viewAllBtn.addEventListener('click', () => {
+      if (!rootEl) return;
+      openModal('shearers-modal');
+    });
+
+    modal.addEventListener('click', e => {
+      if (!rootEl) return;
+      if (e.target.matches('[data-close-modal], .siq-modal__backdrop')) {
+        closeModal('shearers-modal');
+      }
+    });
+
+    const onSnap = snap => {
+      const sessions = [];
+      snap.forEach(doc => sessions.push(doc));
+      cachedSessions = sessions;
+      const years = deriveYearsFromSessions(sessions);
+      yearSel.innerHTML = years.map(y => `<option value="${y}">${y}</option>`).join('');
+      if (viewSel.value !== 'year') yearSel.hidden = true;
+      scheduleRender();
+    };
+    const onError = err => {
+      console.error('[Top5Shearers] listener error:', err);
+      listEl.innerHTML = '<p class="siq-inline-error">Data unavailable</p>';
+    };
+
+    try {
+      const db = firebase.firestore ? firebase.firestore() : (typeof getFirestore === 'function' ? getFirestore() : null);
+      if (!db) throw new Error('Firestore not initialized');
+      colRef = db.collection('contractors').doc(contractorId).collection('sessions');
+      shearersUnsub = colRef.onSnapshot(onSnap, onError);
+    } catch (err) {
+      console.error('[Top5Shearers] init failed:', err);
+      listEl.innerHTML = '<p class="siq-inline-error">Data unavailable</p>';
+    }
+
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) {
+        if (shearersUnsub) {
+          shearersUnsub();
+          shearersUnsub = null;
+        }
+      } else if (!shearersUnsub && colRef) {
+        shearersUnsub = colRef.onSnapshot(onSnap, onError);
+      }
+    });
+    window.addEventListener('beforeunload', () => {
+      if (shearersUnsub) shearersUnsub();
+    });
+  })();
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const overlay = document.getElementById('loading-overlay');
   if (overlay) overlay.style.display = 'flex';
@@ -89,6 +436,10 @@ document.addEventListener('DOMContentLoaded', () => {
         btnChangePin.addEventListener('click', () => {
           window.location.href = 'change-pin.html';
         });
+      }
+
+      if (localStorage.getItem('dash_top5_shearers_enabled') !== 'false') {
+        try { initTop5ShearersWidget(); } catch (e) { console.error('[Top5Shearers] init error', e); }
       }
     } catch (err) {
       console.error('Failed to fetch contractor profile', err);

--- a/public/styles.css
+++ b/public/styles.css
@@ -448,3 +448,169 @@ button {
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
 }
+
+/* === Top 5 Shearers Widget === */
+#top5-shearers {
+  background: #0f1115;
+  border: 1px solid #1c1f27;
+  border-radius: 16px;
+  padding: 16px;
+  margin-bottom: 16px;
+  box-shadow: 0 6px 20px rgba(0,0,0,0.25);
+}
+#top5-shearers .dash-card__header {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+#top5-shearers .dash-card__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+#top5-shearers .dash-card__controls {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+#top5-shearers .siq-link-button {
+  background: transparent;
+  border: none;
+  color: #b9c2d0;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+/* Segmented control */
+#top5-shearers .siq-segmented {
+  display: inline-flex;
+  background: #12151b;
+  border: 1px solid #222633;
+  border-radius: 999px;
+  padding: 2px;
+}
+#top5-shearers .siq-segmented__btn {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: #b9c2d0;
+  padding: 6px 12px;
+  border-radius: 999px;
+  cursor: pointer;
+}
+#top5-shearers .siq-segmented__btn.is-active {
+  background: linear-gradient(180deg,#3a3f51,#2a2f40);
+  color: #fff;
+}
+
+/* View / Year selectors */
+#top5-shearers .view-select {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+}
+#top5-shearers .view-select select {
+  background: #12151b;
+  color: #dfe6f1;
+  border: 1px solid #222633;
+  border-radius: 8px;
+  padding: 6px 10px;
+  outline: none;
+}
+#top5-shearers .year-select[hidden] { display: none; }
+
+/* Leaderboard */
+#top5-shearers .siq-leaderboard {
+  display: grid;
+  gap: 10px;
+  margin-top: 12px;
+}
+#top5-shearers .siq-lb-row {
+  display: grid;
+  grid-template-columns: 40px 1fr 90px;
+  align-items: center;
+  gap: 10px;
+}
+#top5-shearers .siq-lb-rank {
+  color: #8c94a7;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+#top5-shearers .siq-lb-bar {
+  position: relative;
+  height: 14px;
+  background: #141824;
+  border-radius: 999px;
+  overflow: hidden;
+  border: 1px solid #1e2330;
+}
+#top5-shearers .siq-lb-fill {
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  width: 0%;
+  background: linear-gradient(90deg, #b58b2a, #f0cd66);
+  box-shadow: inset 0 0 8px rgba(255,255,255,0.08);
+  transition: width 420ms ease;
+}
+#top5-shearers .siq-lb-name {
+  position: absolute;
+  left: 8px; top: 50%;
+  transform: translateY(-50%);
+  font-size: 0.85rem;
+  color: #e7ecf6;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+#top5-shearers .siq-lb-value {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+#top5-shearers .siq-inline-error {
+  color: #b9c2d0;
+  font-size: 0.9rem;
+}
+
+/* Modal */
+#shearers-modal.siq-modal {
+  position: fixed;
+  inset: 0;
+  display: none;
+  z-index: 1000;
+}
+#shearers-modal[aria-hidden="false"] { display: block; }
+#shearers-modal .siq-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,0.55);
+}
+#shearers-modal .siq-modal__panel {
+  position: absolute;
+  right: 24px; left: 24px; top: 10vh;
+  margin: 0 auto; max-width: 860px;
+  background: #0f1115; border: 1px solid #21283a; border-radius: 14px;
+  box-shadow: 0 18px 48px rgba(0,0,0,0.45);
+}
+#shearers-modal .siq-modal__header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 12px 16px; border-bottom: 1px solid #1b2130;
+}
+#shearers-modal .siq-modal__body { padding: 12px 16px 18px; }
+#shearers-modal .siq-modal__close {
+  background: transparent; border: none; color: #c8d0e0; font-size: 22px; cursor: pointer;
+}
+#shearers-modal .siq-table-scroll { overflow: auto; max-height: 60vh; }
+#shearers-modal .siq-rank-table { width: 100%; border-collapse: collapse; }
+#shearers-modal .siq-rank-table th, #shearers-modal .siq-rank-table td {
+  padding: 8px 10px; border-bottom: 1px solid #1b2130; text-align: left;
+}
+#shearers-modal .siq-rank-table th { color: #9aa3b6; font-weight: 600; }
+#shearers-modal .siq-rank-table td { color: #dfe6f1; }
+#shearers-modal .siq-rank-table td:nth-child(1),
+#shearers-modal .siq-rank-table td:nth-child(3),
+#shearers-modal .siq-rank-table td:nth-child(4) {
+  text-align: right; font-variant-numeric: tabular-nums;
+}


### PR DESCRIPTION
## Summary
- add top 5 shearers dashboard card with work-type and view filters
- include live Firestore session listener and full rankings modal
- style widget and modal with scoped dark-theme CSS

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899c2209dac8321aab12dd43f0e7619