### PR TITLE
feat: compact top shearers widget

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -44,33 +44,36 @@
       <h2 id="dashboard-heading">Contractor Dashboard</h2>
       <p id="dashboard-subheading"></p>
     </div>
-    <!-- BEGIN: Top 5 Shearers Widget -->
-    <section id="top5-shearers" class="dash-card">
-      <header class="dash-card__header">
-        <h2 class="dash-card__title">Top 5 Shearers</h2>
-        <div class="dash-card__controls">
-          <!-- Work type tabs -->
-          <div class="siq-segmented" id="worktype-tabs">
-            <button type="button" data-worktype="shorn" class="siq-segmented__btn is-active">Shorn</button>
-            <button type="button" data-worktype="crutched" class="siq-segmented__btn">Crutched</button>
+    <div class="dash-grid">
+      <!-- BEGIN: Top 5 Shearers Widget -->
+      <section id="top5-shearers" class="dash-card">
+        <header class="dash-card__header">
+          <h2 class="dash-card__title">Top 5 Shearers</h2>
+          <div class="dash-card__controls">
+            <!-- Work type tabs -->
+            <div class="siq-segmented" id="worktype-tabs">
+              <button type="button" data-worktype="shorn" class="siq-segmented__btn is-active">Shorn</button>
+              <button type="button" data-worktype="crutched" class="siq-segmented__btn">Crutched</button>
+            </div>
+            <!-- View selector -->
+            <div class="view-select">
+              <label for="shearers-view">View</label>
+              <select id="shearers-view">
+                <option value="12m" selected>12M Rolling</option>
+                <option value="all">All‑Time</option>
+              </select>
+              <select id="shearers-year" class="year-select" aria-label="Specific year" hidden></select>
+            </div>
+            <button type="button" id="shearers-viewall" class="siq-link-button">View Full List</button>
           </div>
-          <!-- View selector -->
-          <div class="view-select">
-            <label for="shearers-view">View</label>
-            <select id="shearers-view">
-              <option value="12m" selected>12M Rolling</option>
-              <option value="all">All‑Time</option>
-            </select>
-            <select id="shearers-year" class="year-select" aria-label="Specific year" hidden></select>
-          </div>
-          <button type="button" id="shearers-viewall" class="siq-link-button">View Full List</button>
-        </div>
-      </header>
+        </header>
 
-      <div id="top5-shearers-list" class="siq-leaderboard">
-        <!-- JS renders 5 rows with bars -->
-      </div>
-    </section>
+        <div id="top5-shearers-list" class="siq-leaderboard">
+          <!-- JS renders 5 rows with bars -->
+        </div>
+      </section>
+      <!-- When we add the other 3 widgets, they’ll sit beside this one on wide screens -->
+    </div>
 
     <!-- Full list modal -->
     <div id="shearers-modal" class="siq-modal" aria-hidden="true">

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -26,6 +26,16 @@ function initTop5ShearersWidget() {
 
     const listEl = rootEl.querySelector('#top5-shearers-list');
     const viewSel = rootEl.querySelector('#shearers-view');
+    // Relabel 12M option to current year (purely visual)
+    (function labelRollingWithYear(sel) {
+      if (!sel) return;
+      const opt = [...sel.options].find(o => o.value === '12m');
+      if (!opt) return;
+      const y = new Date().getFullYear();
+      // Choose one:
+      // opt.textContent = String(y);           // just the year
+      opt.textContent = `${y} (12M)`;           // clearer it's rolling
+    })(viewSel);
     const yearSel = rootEl.querySelector('#shearers-year');
     const viewAllBtn = rootEl.querySelector('#shearers-viewall');
     const tabs = rootEl.querySelector('#worktype-tabs');

--- a/public/styles.css
+++ b/public/styles.css
@@ -614,3 +614,85 @@ button {
 #shearers-modal .siq-rank-table td:nth-child(4) {
   text-align: right; font-variant-numeric: tabular-nums;
 }
+
+/* === Dashboard compact grid for small widgets === */
+#page-content .dash-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 12px;
+  align-items: start;
+}
+
+/* Compact card */
+#top5-shearers.dash-card {
+  padding: 12px;
+  border-radius: 12px;
+  margin-bottom: 12px;
+}
+
+/* Header & controls condensed */
+#top5-shearers .dash-card__header {
+  gap: 8px;
+}
+#top5-shearers .dash-card__title {
+  font-size: 0.95rem;
+}
+#top5-shearers .dash-card__controls {
+  gap: 6px;
+}
+#top5-shearers .siq-segmented {
+  padding: 1px;
+}
+#top5-shearers .siq-segmented__btn {
+  padding: 4px 8px;
+  font-size: 0.85rem;
+}
+#top5-shearers .view-select select {
+  padding: 4px 8px;
+  font-size: 0.85rem;
+}
+#top5-shearers .siq-link-button {
+  font-size: 0.85rem;
+}
+
+/* Leaderboard condensed */
+#top5-shearers .siq-leaderboard {
+  gap: 8px;
+  margin-top: 8px;
+}
+#top5-shearers .siq-lb-row {
+  grid-template-columns: 28px 1fr 64px;
+  gap: 8px;
+}
+#top5-shearers .siq-lb-rank {
+  font-size: 0.85rem;
+}
+#top5-shearers .siq-lb-bar {
+  height: 10px;
+  border-radius: 999px;
+}
+#top5-shearers .siq-lb-fill {
+  transition: width 320ms ease;
+}
+#top5-shearers .siq-lb-name {
+  font-size: 0.8rem;
+  left: 6px;
+}
+#top5-shearers .siq-lb-value {
+  font-size: 0.85rem;
+}
+
+/* Modal compact */
+#shearers-modal .siq-modal__panel {
+  max-width: 720px;
+}
+#shearers-modal .siq-modal__body {
+  padding: 10px 14px 14px;
+}
+#shearers-modal .siq-rank-table th,
+#shearers-modal .siq-rank-table td {
+  padding: 6px 8px;
+  font-size: 0.92rem;
+}
+
+/* Mobile: single column naturally via grid; no extra rules needed */


### PR DESCRIPTION
## Summary
- Make Top 5 Shearers widget more compact and responsive
- Wrap dashboard widgets in a grid container for future expansion
- Relabel 12M rolling view to show the current year

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899c8309784832195dd6720c883e4e8