### PR TITLE
Add Firestore quick stats widget

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Dashboard - SHEAR iQ</title>
-  <link rel="stylesheet" href="styles.css?v=readability2">
+  <link rel="stylesheet" href="styles.css?v=quickstats-fs1">
   <style>
     body {
       display: flex;
@@ -73,6 +73,42 @@
         </div>
       </section>
       <!-- When we add the other 3 widgets, they’ll sit beside this one on wide screens -->
+      <!-- BEGIN: Quick Stats Widget -->
+      <section id="quick-stats" class="dash-card">
+        <header class="dash-card__header">
+          <h2 class="dash-card__title">Quick Stats</h2>
+          <div class="dash-card__controls">
+            <div class="view-select">
+              <label for="stats-view">View</label>
+              <select id="stats-view">
+                <option value="12m" selected>12M Rolling</option>
+                <option value="all">All‑Time</option>
+                <option value="year">Specific Year</option>
+              </select>
+              <select id="stats-year" class="year-select" aria-label="Specific year" hidden></select>
+            </div>
+          </div>
+        </header>
+        <div class="siq-stats-grid">
+          <div class="siq-stat-card">
+            <div class="siq-stat-label">Total Sheep</div>
+            <div class="siq-stat-value" id="stat-total-sheep">—</div>
+          </div>
+          <div class="siq-stat-card">
+            <div class="siq-stat-label">Total Hours</div>
+            <div class="siq-stat-value" id="stat-total-hours">—</div>
+          </div>
+          <div class="siq-stat-card">
+            <div class="siq-stat-label">Most Productive Farm</div>
+            <div class="siq-stat-value" id="stat-top-farm">—</div>
+          </div>
+          <div class="siq-stat-card">
+            <div class="siq-stat-label">Avg Sheep / Visit</div>
+            <div class="siq-stat-value" id="stat-avg-sheep">—</div>
+          </div>
+        </div>
+      </section>
+      <!-- END: Quick Stats Widget -->
     </div>
 
     <!-- Full list modal -->

--- a/public/styles.css
+++ b/public/styles.css
@@ -792,3 +792,18 @@ button {
 #top5-shearers .siq-lb-fill {
   filter: saturate(110%);
 }
+
+/* === Quick Stats (Firestore) — scoped === */
+#quick-stats {
+  background:#0f1115; border:1px solid #1c1f27; border-radius:12px; padding:12px; box-shadow:0 6px 20px rgba(0,0,0,0.25);
+}
+#quick-stats .dash-card__header { display:flex; gap:8px; align-items:center; justify-content:space-between; flex-wrap:wrap; }
+#quick-stats .dash-card__title { margin:0; font-size:0.95rem; font-weight:600; }
+#quick-stats .dash-card__controls { display:flex; gap:6px; align-items:center; flex-wrap:wrap; }
+#quick-stats .year-select[hidden] { display:none; }
+
+.siq-stats-grid { display:grid; grid-template-columns: repeat(2, 1fr); gap:10px; margin-top:8px; }
+@media (min-width: 860px) { .siq-stats-grid { grid-template-columns: repeat(4, 1fr); } }
+.siq-stat-card { background:#12151b; border:1px solid #222633; border-radius:10px; padding:10px; display:flex; flex-direction:column; gap:6px; }
+.siq-stat-label { color:#9aa3b6; font-size:0.85rem; }
+.siq-stat-value { color:#fff; font-size:1.25rem; font-weight:800; letter-spacing:0.2px; }


### PR DESCRIPTION
## Summary
- Add Quick Stats widget to dashboard showing total sheep, staff hours, top farm, and average sheep per visit with view filters
- Style Quick Stats card for responsive layout
- Initialize Quick Stats widget alongside existing widgets

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899f3fd56a48321a6e0e133d5d68462