### PR TITLE
Normalize service worker caching for versioned assets

### DIFF
--- a/public/tally.html
+++ b/public/tally.html
@@ -338,7 +338,7 @@
 
 <script src="xlsx.full.min.js"></script>
 <script type="module" src="auth.js"></script>
- <script src="/tally.js?v=help-in-tour-2"></script>
+<script src="/tally.js"></script>
 <script src="export.js"></script>
 
   </div> <!-- tallySheetView -->


### PR DESCRIPTION
## Summary
- remove query parameter when loading `tally.js` so it matches cached entry
- teach service worker to strip query strings when matching/storing files and bump cache version

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3c0d7c2dc8321895f2792cbb64c86