### PR TITLE
feat: centralize session state

### DIFF
--- a/public/app-launch-guard.js
+++ b/public/app-launch-guard.js
@@ -23,7 +23,7 @@
 
   if (!coldEntry()) return;
 
-  const role = (localStorage.getItem('user_role') || '').toLowerCase();
+  const role = (SessionState.get().user_role || '').toLowerCase();
 
   if (role === 'contractor') {
     if (!pageIs('dashboard.html')) redirect('dashboard.html');

--- a/public/auth-check.html
+++ b/public/auth-check.html
@@ -20,6 +20,7 @@
   <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
   <script src="firebase-init.js"></script>
+  <script src="session-state.js"></script>
 </head>
 <body>
 <!-- Tiny early guard (does NOT replace auth security; just avoids spinner stalls) -->
@@ -27,7 +28,7 @@
 try {
   // If we have a known role and user is already authenticated, bounce quickly.
   // The full auth-check.js will still run right after and re-verify.
-  var role = localStorage.getItem('user_role');
+  var role = SessionState.get().user_role;
   if (role === 'contractor') {
     // If someone opens auth-check directly and they’re a contractor, they expect dashboard
     if (!location.pathname.endsWith('dashboard.html')) location.replace('dashboard.html');

--- a/public/auth-check.js
+++ b/public/auth-check.js
@@ -1,7 +1,7 @@
 // === FAST PATH: bootstrap redirect from localStorage (works offline) ===
 (function fastRoleBootstrap(){
   try {
-    const role = localStorage.getItem('user_role');
+    const role = SessionState.get().user_role;
     if (role === 'contractor') {
       // Contractors always land on the dashboard
       window.location.replace('dashboard.html');
@@ -22,7 +22,7 @@
 // Watchdog: if auth checks take too long but we do have a saved role, go anyway.
 (function watchdogRedirect(){
   try {
-    const savedRole = localStorage.getItem('user_role');
+    const savedRole = SessionState.get().user_role;
     if (!savedRole) return; // nothing to do
 
     setTimeout(() => {
@@ -55,8 +55,7 @@ firebase.auth().onAuthStateChanged(async function (user) {
 
   if (contractorSnap.exists && contractorSnap.data().role === "contractor") {
     console.log("[auth-check] \u2705 User is a contractor");
-    localStorage.setItem("contractor_id", userUid);
-    localStorage.setItem('user_role', 'contractor'); // NEW
+    SessionState.set('contractor', userUid);
     console.log('[auth-check] role=contractor saved');
     window.location.href = "dashboard.html";
     window.__authCheckRedirected = true;
@@ -84,13 +83,12 @@ firebase.auth().onAuthStateChanged(async function (user) {
 
         if (contractorId) {
           try {
-            localStorage.setItem("contractor_id", contractorId);
-            localStorage.setItem('user_role', 'staff'); // NEW
+            SessionState.set('staff', contractorId);
             console.log('[auth-check] role=staff saved');
             window.location.href = "tally.html";
             window.__authCheckRedirected = true;
           } catch (e) {
-            console.error("\u274c Failed to set contractor_id in localStorage:", e);
+            console.error("\u274c Failed to set contractor_id:", e);
             await firebase.auth().signOut();
             window.location.href = "login.html";
           }

--- a/public/auth.js
+++ b/public/auth.js
@@ -3,13 +3,13 @@ if ('serviceWorker' in navigator) {
     .catch(console.error);
 }
 
-firebase.auth().onAuthStateChanged(user => {
-  if (!user) {
+SessionState.ready().then(state => {
+  if (!state.uid) {
     window.location.href = 'login.html';
   }
 });
 
-export function handleLogout() {
+export async function handleLogout() {
   const confirmed = confirm(
     'Warning: You won’t be able to log back in without internet access. Are you sure you want to log out?'
   );
@@ -20,17 +20,16 @@ export function handleLogout() {
   if (overlay) {
     overlay.style.display = 'flex';
   }
-  firebase.auth().signOut().finally(() => {
+  try {
+    await firebase.auth().signOut();
+  } finally {
     if (overlay) {
       overlay.style.display = 'none';
     }
-    try {
-      localStorage.removeItem('user_role');
-      localStorage.removeItem('contractor_id');
-    } catch (_) {}
+    SessionState.clear();
     sessionStorage.clear();
     window.location.replace('login.html');
-  });
+  }
 }
 
 document.getElementById('logoutBtn')?.addEventListener('click', handleLogout);

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -34,6 +34,7 @@
   <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
   <script src="firebase-init.js"></script>
+  <script src="session-state.js"></script>
   <script type="module" src="auth.js"></script>
   <!-- PWA manifest -->
   <link rel="manifest" href="/manifest.json">
@@ -64,7 +65,7 @@
       }
 
       var cold = navIsCold();
-      var role = (localStorage.getItem('user_role') || '').toLowerCase();
+      var role = (SessionState.get().user_role || '').toLowerCase();
       var pref = (localStorage.getItem('preferred_start') || '').toLowerCase();
 
       var want = role === 'contractor' ? 'dashboard'
@@ -250,7 +251,6 @@
   <script src="app-launch-guard.js" defer></script>
   <script>
     try {
-      localStorage.setItem('user_role', 'contractor');
       localStorage.setItem('preferred_start', 'dashboard');
     } catch(e) {}
   </script>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -11,7 +11,7 @@ function shouldShowDashboardWelcomeOnce(){
     if (enabled === 'false') return false;
 
     // Role guard (optional but nice): only contractors see this dashboard intro
-    var role = (localStorage.getItem('user_role') || '').toLowerCase();
+    var role = (SessionState.get().user_role || '').toLowerCase();
     if (role && role !== 'contractor') return false;
 
     return true;
@@ -47,7 +47,6 @@ function markDashboardWelcomeSeen(){
 document.addEventListener('DOMContentLoaded', function(){
   try {
     // Contractor default role/pref (as you already do elsewhere)
-    localStorage.setItem('user_role','contractor');
     localStorage.setItem('preferred_start','dashboard');
   } catch(e){}
 
@@ -87,11 +86,26 @@ window.resetDashboardWelcomeOnce = function(){
 };
 
 try {
-  localStorage.setItem('user_role', 'contractor');
   localStorage.setItem('preferred_start', 'dashboard');
 } catch(e) {}
 
 import { handleLogout } from './auth.js';
+
+SessionState.ready().then(state => {
+  if (state.user_role !== 'contractor') {
+    window.location.replace('auth-check.html');
+  }
+});
+
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') {
+    SessionState.ready().then(s => {
+      if (s.user_role !== 'contractor') {
+        window.location.replace('auth-check.html');
+      }
+    });
+  }
+});
 
 function initTop5ShearersWidget() {
   (function () {
@@ -102,10 +116,10 @@ function initTop5ShearersWidget() {
       return;
     }
     // Prefer stored scope; fall back to current auth user
-    let contractorId = localStorage.getItem('contractor_id');
+    let contractorId = SessionState.get().contractor_id;
     if (!contractorId && firebase?.auth?.currentUser?.uid) {
       contractorId = firebase.auth().currentUser.uid;
-      try { localStorage.setItem('contractor_id', contractorId); } catch {}
+      SessionState.set(SessionState.get().user_role, contractorId);
       console.debug('[Top5Shearers] contractor_id recovered from auth');
     }
     if (!contractorId) {
@@ -551,7 +565,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       // Persist contractor scope for dashboard widgets
       try {
-        localStorage.setItem('contractor_id', user.uid);
+        SessionState.set('contractor', user.uid);
         console.debug('[Dashboard] contractor_id set to', user.uid);
       } catch (e) {
         console.warn('[Dashboard] Could not set contractor_id:', e);

--- a/public/login.html
+++ b/public/login.html
@@ -42,6 +42,7 @@
   <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
   <script src="firebase-init.js"></script>
+  <script src="session-state.js"></script>
   <script src="login.js"></script>
 </head>
 <body>

--- a/public/login.js
+++ b/public/login.js
@@ -77,7 +77,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const contractorDoc = await db.collection('contractors').doc(uid).get();
       if (contractorDoc.exists) {
         // Use replace to ensure a hard reload after login
-        localStorage.setItem('user_role', 'contractor');
+        SessionState.set('contractor', uid);
         console.log('[login] role=contractor saved');
         window.location.href = 'dashboard.html';
         return;
@@ -102,9 +102,8 @@ document.addEventListener('DOMContentLoaded', () => {
       });
 
       if (foundContractorId) {
-        localStorage.setItem('contractor_id', foundContractorId);
-        console.log('[login] 💾 contractor_id stored in localStorage:', foundContractorId);
-        localStorage.setItem('user_role', 'staff');
+        SessionState.set('staff', foundContractorId);
+        console.log('[login] contractor_id stored:', foundContractorId);
         console.log('[login] role=staff saved');
         window.location.href = 'tally.html';
       } else {

--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-  <title>Manage Staff - SHEAR iQ</title>
+<title>Manage Staff - SHEAR iQ</title>
   <link rel="stylesheet" href="styles.css">
   <style>
     html, body {
@@ -402,6 +402,11 @@
       </div>
     </div>
   </div>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
+  <script src="firebase-init.js"></script>
+  <script src="session-state.js"></script>
   <script type="module" src="manage-staff.js"></script>
 
   <div id="loading-overlay">

--- a/public/manage-staff.js
+++ b/public/manage-staff.js
@@ -19,6 +19,22 @@ const functions = getFunctions(app);
 const STAFF_LIMIT = 10;
 const DELETED_STAFF_STATE_KEY = 'deletedStaffSectionState';
 
+SessionState.ready().then(state => {
+  if (state.user_role !== 'contractor') {
+    window.location.replace('auth-check.html');
+  }
+});
+
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') {
+    SessionState.ready().then(s => {
+      if (s.user_role !== 'contractor') {
+        window.location.replace('auth-check.html');
+      }
+    });
+  }
+});
+
 let actionOverlay, actionOverlayText, confirmModal, confirmMessage, confirmYesBtn, confirmCancelBtn;
 
 function showActionOverlay(message) {
@@ -166,7 +182,7 @@ async function deleteStaff(btn) {
   const { uid, name } = btn.dataset;
   const confirmed = await showConfirm(`Are you sure you want to delete ${name || 'this staff user'}?`);
   if (!confirmed) return;
-  const contractorId = localStorage.getItem('contractor_id');
+  const contractorId = SessionState.get().contractor_id;
   if (!contractorId) {
     alert('Missing contractor id');
     return;
@@ -190,7 +206,7 @@ async function restoreStaff(btn) {
   const { logid, name } = btn.dataset;
   const confirmed = await showConfirm(`Are you sure you want to restore ${name || 'this staff user'}?`);
   if (!confirmed) return;
-  const contractorId = localStorage.getItem('contractor_id');
+  const contractorId = SessionState.get().contractor_id;
   if (!contractorId) {
     alert('Missing contractor id');
     return;
@@ -266,7 +282,7 @@ async function restoreStaff(btn) {
       }
 
       const contractorUid = user.uid;
-      localStorage.setItem('contractor_id', contractorUid);
+      SessionState.set('contractor', contractorUid);
       await loadStaffList(contractorUid);
 
       const deletedSearchInput = document.getElementById('deletedStaffSearch');

--- a/public/session-state.js
+++ b/public/session-state.js
@@ -1,0 +1,106 @@
+(function(){
+  const state = {
+    uid: null,
+    user_role: null,
+    contractor_id: null,
+    ready: false
+  };
+
+  try {
+    state.user_role = localStorage.getItem('user_role');
+    state.contractor_id = localStorage.getItem('contractor_id');
+  } catch (e) {}
+
+  let resolveReady;
+  const readyPromise = new Promise(res => { resolveReady = res; });
+
+  function emit(){
+    window.dispatchEvent(new CustomEvent('session-state-changed', {detail: {...state}}));
+  }
+
+  if (window.firebase && firebase.auth) {
+    firebase.auth().onAuthStateChanged(async user => {
+      if (!user) {
+        state.uid = null;
+        state.user_role = null;
+        state.contractor_id = null;
+        state.ready = true;
+        try {
+          localStorage.removeItem('user_role');
+          localStorage.removeItem('contractor_id');
+        } catch(e){}
+        emit();
+        resolveReady(state);
+        return;
+      }
+
+      state.uid = user.uid;
+      let role = state.user_role;
+      let contractorId = state.contractor_id;
+
+      if (!role || (role === 'staff' && !contractorId)) {
+        try {
+          const db = firebase.firestore();
+          const contractorSnap = await db.collection('contractors').doc(user.uid).get();
+          if (contractorSnap.exists && contractorSnap.data().role === 'contractor') {
+            role = 'contractor';
+            contractorId = user.uid;
+          } else {
+            const staffQuery = await db
+              .collectionGroup('staff')
+              .where(firebase.firestore.FieldPath.documentId(), '==', user.uid)
+              .limit(1)
+              .get();
+            if (!staffQuery.empty) {
+              const data = staffQuery.docs[0].data();
+              if ((data.role || '').toLowerCase() === 'staff') {
+                role = 'staff';
+                contractorId = data.contractorId;
+              }
+            }
+          }
+        } catch(err){ console.error('[SessionState] role lookup failed', err); }
+        try {
+          if (role) localStorage.setItem('user_role', role); else localStorage.removeItem('user_role');
+          if (contractorId) localStorage.setItem('contractor_id', contractorId); else localStorage.removeItem('contractor_id');
+        } catch(e){}
+      }
+
+      state.user_role = role;
+      state.contractor_id = contractorId;
+      state.ready = true;
+      emit();
+      resolveReady(state);
+    });
+  } else {
+    // If firebase isn't ready yet, resolve immediately with whatever is cached
+    state.ready = true;
+    resolveReady(state);
+  }
+
+  window.SessionState = {
+    ready: () => readyPromise,
+    get: () => ({...state}),
+    onChange: (fn) => window.addEventListener('session-state-changed', e => fn(e.detail)),
+    set: (role, contractorId) => {
+      state.user_role = role || null;
+      state.contractor_id = contractorId || null;
+      try {
+        if (state.user_role) localStorage.setItem('user_role', state.user_role); else localStorage.removeItem('user_role');
+        if (state.contractor_id) localStorage.setItem('contractor_id', state.contractor_id); else localStorage.removeItem('contractor_id');
+      } catch(e){}
+      emit();
+    },
+    clear: () => {
+      state.uid = null;
+      state.user_role = null;
+      state.contractor_id = null;
+      state.ready = true;
+      try {
+        localStorage.removeItem('user_role');
+        localStorage.removeItem('contractor_id');
+      } catch(e){}
+      emit();
+    }
+  };
+})();

--- a/public/tally.html
+++ b/public/tally.html
@@ -36,6 +36,7 @@
   <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
   <script src="firebase-init.js"></script>
+  <script src="session-state.js"></script>
   <!-- PWA Manifest -->
     <link rel="manifest" href="manifest.json" />
 
@@ -150,7 +151,7 @@
     }
 
     var cold = navIsCold();
-    var role = (localStorage.getItem('user_role') || '').toLowerCase();
+    var role = (SessionState.get().user_role || '').toLowerCase();
     var pref = (localStorage.getItem('preferred_start') || '').toLowerCase();
 
     var want = role === 'contractor' ? 'dashboard'
@@ -841,9 +842,6 @@ document.addEventListener('DOMContentLoaded', () => {
   <script src="app-launch-guard.js" defer></script>
   <script>
     try {
-      if (!localStorage.getItem('user_role')) {
-        localStorage.setItem('user_role', 'staff');
-      }
       localStorage.setItem('preferred_start', 'tally');
     } catch(e) {}
   </script>

--- a/public/tally.js
+++ b/public/tally.js
@@ -28,6 +28,22 @@ function detectAgeCategory(sheepTypeName) {
   return 'unknown';
 }
 
+SessionState.ready().then(state => {
+  if (state.user_role !== 'staff') {
+    window.location.replace('auth-check.html');
+  }
+});
+
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') {
+    SessionState.ready().then(s => {
+      if (s.user_role !== 'staff') {
+        window.location.replace('auth-check.html');
+      }
+    });
+  }
+});
+
 document.addEventListener('DOMContentLoaded', () => {
   if (!document.getElementById('tt-root')) {
     const tt = document.createElement('div');
@@ -2297,7 +2313,7 @@ async function verifyContractorUser() {
   const contractorSnap = await db.collection('contractors').doc(user.uid).get();
   if (contractorSnap.exists) {
     console.log('[verifyContractorUser] User is a contractor');
-    localStorage.setItem('contractor_id', user.uid);
+    SessionState.set('contractor', user.uid);
     return 'contractor';
   }
 
@@ -2319,7 +2335,7 @@ async function verifyContractorUser() {
             .collection('staff')
             .doc(staffUid)
             .update({ lastActive: firebase.firestore.FieldValue.serverTimestamp() });
-    localStorage.setItem('contractor_id', contractorId);
+    SessionState.set('staff', contractorId);
     console.log('[verifyContractorUser] Found matching staff for contractor', contractorId);
     return 'staff';
   }
@@ -2351,9 +2367,9 @@ async function saveSessionToFirestore(showStatus = false) {
   }
 
   // ✅ Use contractorId from localStorage
-  const contractorId = localStorage.getItem('contractor_id');
+  const contractorId = SessionState.get().contractor_id;
   if (!contractorId) {
-    console.error('Missing contractor_id in localStorage');
+    console.error('Missing contractor_id');
     return;
   }
 
@@ -2383,7 +2399,7 @@ async function listSessionsFromFirestore() {
         return [];
     }
 
-    const contractorId = localStorage.getItem('contractor_id');
+    const contractorId = SessionState.get().contractor_id;
     if (!contractorId) {
         console.error('Missing contractor_id');
         return [];
@@ -2424,7 +2440,7 @@ async function loadSessionFromFirestore(id) {
         return null;
     }
 
-    const contractorId = localStorage.getItem('contractor_id');
+    const contractorId = SessionState.get().contractor_id;
     if (!contractorId) {
         console.error('Missing contractor_id');
         return null;

--- a/public/view-sessions.html
+++ b/public/view-sessions.html
@@ -20,6 +20,7 @@
   <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
   <script src="firebase-init.js"></script>
+  <script src="session-state.js"></script>
 </head>
 <body>
   <div id="page-content" style="display: none;">

--- a/public/view-sessions.js
+++ b/public/view-sessions.js
@@ -11,6 +11,22 @@ function formatNZDate(iso) {
   return `${day}/${month}/${year}`;
 }
 
+SessionState.ready().then(state => {
+  if (state.user_role !== 'contractor') {
+    window.location.replace('auth-check.html');
+  }
+});
+
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') {
+    SessionState.ready().then(s => {
+      if (s.user_role !== 'contractor') {
+        window.location.replace('auth-check.html');
+      }
+    });
+  }
+});
+
 async function fetchSessions(contractorId) {
   const listEl = document.getElementById('sessionList');
   if (!listEl) return;
@@ -121,7 +137,7 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
       }
       const contractorId = doc.id;
-      localStorage.setItem('contractor_id', contractorId);
+      SessionState.set('contractor', contractorId);
       await fetchSessions(contractorId);
 
       const page = document.getElementById('page-content');


### PR DESCRIPTION
## Summary
- add SessionState module to manage {uid, role, contractor_id} from one source
- refactor login/auth pages to read and write through SessionState
- gate dashboard, tally and management pages on resolved session state and clear routing keys on logout

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a3cb71fb648321a00cdc91511776a0