### PR TITLE
handle offline state in auth check

### DIFF
--- a/public/auth-check.js
+++ b/public/auth-check.js
@@ -1,36 +1,53 @@
-firebase.auth().onAuthStateChanged(async function (user) {
-  if (!user) {
-    window.location.href = "login.html";
-    return;
+function showOfflineMessage() {
+  const overlay = document.getElementById("loading-overlay");
+  if (overlay) {
+    overlay.innerHTML = "You are offline. Please check your connection.<br><button id=\"retry-btn\">Retry</button>";
+    const btn = document.getElementById("retry-btn");
+    if (btn) btn.addEventListener("click", () => window.location.reload());
+  } else {
+    alert("You are offline. Please check your connection.");
   }
+}
 
-  const db = firebase.firestore();
-  const userUid = user.uid;
+function handleOffline() {
+  showOfflineMessage();
+  window.addEventListener("online", () => window.location.reload(), { once: true });
+}
 
-  console.log("[auth-check] \ud83d\udd0d Checking user role for UID:", userUid);
+function initAuthListener() {
+  firebase.auth().onAuthStateChanged(async function (user) {
+    if (!user) {
+      window.location.href = "login.html";
+      return;
+    }
 
-  // Step 1: Check if user is a contractor
-  const contractorRef = db.collection("contractors").doc(userUid);
-  const contractorSnap = await contractorRef.get();
+    const db = firebase.firestore();
+    const userUid = user.uid;
 
-  if (contractorSnap.exists && contractorSnap.data().role === "contractor") {
-    console.log("[auth-check] \u2705 User is a contractor");
-    localStorage.setItem("contractor_id", userUid);
-    await waitForContractorIdAndRedirect();
-    return;
-  }
+    console.log("[auth-check] \ud83d\udd0d Checking user role for UID:", userUid);
 
-  // Step 2: Search all contractor/staff subcollections for this staff UID
-  console.log("[auth-check] \ud83d\udd0d Not a contractor, searching staff subcollections...");
+    // Step 1: Check if user is a contractor
+    const contractorRef = db.collection("contractors").doc(userUid);
+    const contractorSnap = await contractorRef.get();
 
-  const staffQuery = await db
-    .collectionGroup("staff")
-    .where(firebase.firestore.FieldPath.documentId(), "==", userUid)
-    .get();
+    if (contractorSnap.exists && contractorSnap.data().role === "contractor") {
+      console.log("[auth-check] \u2705 User is a contractor");
+      localStorage.setItem("contractor_id", userUid);
+      await waitForContractorIdAndRedirect();
+      return;
+    }
 
-  if (!staffQuery.empty) {
-    const docSnap = staffQuery.docs[0];
-    const role = docSnap.data().role;
+    // Step 2: Search all contractor/staff subcollections for this staff UID
+    console.log("[auth-check] \ud83d\udd0d Not a contractor, searching staff subcollections...");
+
+    const staffQuery = await db
+      .collectionGroup("staff")
+      .where(firebase.firestore.FieldPath.documentId(), "==", userUid)
+      .get();
+
+    if (!staffQuery.empty) {
+      const docSnap = staffQuery.docs[0];
+      const role = docSnap.data().role;
 
       if (role === "staff") {
         const data = docSnap.data();
@@ -53,17 +70,35 @@ firebase.auth().onAuthStateChanged(async function (user) {
           await firebase.auth().signOut();
           window.location.href = "login.html";
         }
+      } else {
+        console.error("[auth-check] \u274c Staff user not found in any subcollection");
+        await firebase.auth().signOut();
+        window.location.href = "login.html";
+      }
     } else {
       console.error("[auth-check] \u274c Staff user not found in any subcollection");
       await firebase.auth().signOut();
       window.location.href = "login.html";
     }
-  } else {
-    console.error("[auth-check] \u274c Staff user not found in any subcollection");
-    await firebase.auth().signOut();
-    window.location.href = "login.html";
+  }, function (error) {
+    console.error("[auth-check] \u274c onAuthStateChanged failed:", error);
+    if (error && error.code === "auth/network-request-failed") {
+      handleOffline();
+    }
+  });
+}
+
+if (!navigator.onLine) {
+  handleOffline();
+} else {
+  try {
+    firebase.app();
+    initAuthListener();
+  } catch (e) {
+    console.error("[auth-check] \u274c Firebase initialization failed:", e);
+    handleOffline();
   }
-});
+}
 
 async function waitForContractorIdAndRedirect(maxWaitMs = 2000) {
   const start = Date.now();


### PR DESCRIPTION
## Summary
- show message and retry option when Firebase init or auth fails offline
- reload auth check once connectivity returns

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a4127b584883218b205fe406af9f13