### PR TITLE
Handle offline navigation in service worker

### DIFF
--- a/public/offline.html
+++ b/public/offline.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Offline</title>
+  <link rel="stylesheet" href="styles.css">
+  <style>
+    body {
+      margin: 0;
+      height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      background: #f5f5f5;
+      color: #333;
+    }
+  </style>
+</head>
+<body>
+  <div>
+    <p>You are offline or the app could not connect to Firebase.</p>
+  </div>
+  <script>
+    window.addEventListener('load', () => {
+      if (typeof firebase === 'undefined') {
+        console.warn('Firebase failed to initialize.');
+      }
+    });
+  </script>
+</body>
+</html>

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,5 +1,5 @@
 // ✅ Bump the cache version whenever you change this file or add new assets
-const CACHE_NAME = 'sheariq-pwa-v5';
+const CACHE_NAME = 'sheariq-pwa-v6';
 
 const FILES_TO_CACHE = [
   // HTML entry points (include the start_url from manifest)
@@ -8,6 +8,7 @@ const FILES_TO_CACHE = [
   'tally.html',
   'farm-summary.html',
   'login.html',
+  'offline.html',
 
   // App assets (keep existing names; do NOT rename)
   'styles.css',
@@ -53,8 +54,10 @@ self.addEventListener('fetch', event => {
           const fresh = await fetch(event.request);
           return fresh;
         } catch (err) {
-          // Fallback to cached dashboard if offline
-          const cached = await caches.match('dashboard.html');
+          // Fallback to cached auth check page or offline page if offline
+          const cached =
+            (await caches.match('auth-check.html')) ||
+            (await caches.match('offline.html'));
           return cached || Response.error();
         }
       })()


### PR DESCRIPTION
## Summary
- fall back to `auth-check.html` or new `offline.html` when navigation fails
- add `offline.html` to service-worker cache and bump cache version
- provide offline page that handles missing Firebase initialization

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a41278a5548321b2d19886471f072a