### PR TITLE
refactor: migrate auth check to modular

### DIFF
--- a/public/auth-check.html
+++ b/public/auth-check.html
@@ -16,17 +16,12 @@
       user-select: none;
     }
   </style>
-  <script src="firebase-app-compat.js"></script>
-  <script src="firebase-auth-compat.js"></script>
-  <script src="firebase-firestore-compat.js"></script>
-  <script src="firebase-init.js"></script>
 </head>
 <body>
 <div id="loading-overlay" class="show">
   <div class="circle-spinner"></div>
   <div>Checking login… Please wait.</div>
 </div>
-
-  <script src="auth-check.js"></script>
+  <script type="module" src="/auth-check.mod.js"></script>
 </body>
 </html>

--- a/public/auth-check.mod.js
+++ b/public/auth-check.mod.js
@@ -1,0 +1,85 @@
+// public/auth-check.mod.js
+import {
+  auth, db,
+  onAuthStateChanged,
+  doc, getDoc,
+  collectionGroup, query, where, limit, getDocs
+} from "./firebase-core.js";
+
+const redirect = (url) => { window.location.href = url; };
+
+const setContractorId = (id) => {
+  try { localStorage.setItem("contractor_id", id); } catch (_) {}
+};
+
+async function resolveRoleAndRedirect(user) {
+  // Try contractor: contractors/{uid}
+  const contractorRef = doc(db, "contractors", user.uid);
+  const contractorSnap = await getDoc(contractorRef);
+  if (contractorSnap.exists()) {
+    setContractorId(user.uid);
+    redirect("/tally.html");
+    return;
+  }
+
+  // Try staff by uid in collectionGroup('staff')
+  let contractorId = null;
+
+  // 1) Prefer uid match (fast + exact)
+  const qByUid = query(
+    collectionGroup(db, "staff"),
+    where("uid", "==", user.uid),
+    limit(1)
+  );
+  let cgSnap = await getDocs(qByUid);
+  if (!cgSnap.empty) {
+    const snap = cgSnap.docs[0];
+    // Path: contractors/{contractorId}/staff/{staffId}
+    const segments = snap.ref.path.split("/");
+    // ["contractors", "{id}", "staff", "{staffId}"]
+    contractorId = segments[1];
+  } else {
+    // 2) Fallback to email match if older docs don’t store uid
+    // (Optional but preserves legacy behavior)
+    if (user.email) {
+      const qByEmail = query(
+        collectionGroup(db, "staff"),
+        where("email", "==", user.email),
+        limit(1)
+      );
+      cgSnap = await getDocs(qByEmail);
+      if (!cgSnap.empty) {
+        const snap = cgSnap.docs[0];
+        const segments = snap.ref.path.split("/");
+        contractorId = segments[1];
+      }
+    }
+  }
+
+  if (contractorId) {
+    setContractorId(contractorId);
+    redirect("/tally.html");
+    return;
+  }
+
+  // No role doc found → send back to login
+  redirect("/login.html");
+}
+
+function start() {
+  onAuthStateChanged(auth, (user) => {
+    if (!user) {
+      redirect("/login.html");
+      return;
+    }
+    resolveRoleAndRedirect(user).catch((err) => {
+      console.error("[auth-check] role resolution failed:", err);
+      redirect("/login.html");
+    });
+  });
+}
+
+document.readyState === "loading"
+  ? document.addEventListener("DOMContentLoaded", start)
+  : start();
+


### PR DESCRIPTION
## Summary
- replace auth-check compat bundle with modular Firebase auth-check
- load new module in auth-check.html

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a4235ed7448321a9b9fd6c6322b01e