### PR TITLE
Remove obsolete setup and tooltip options

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -225,10 +225,6 @@
       </ul>
       <div class="dw-row" style="margin-top:10px; display:flex; gap:14px; align-items:center; flex-wrap:wrap;">
         <label class="dw-inline">
-          <input type="checkbox" id="dw-enable-welcome">
-          Enable Welcome Popup
-        </label>
-        <label class="dw-inline">
           <input type="checkbox" id="dw-enable-tour">
           Enable Dashboard Tour
         </label>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -888,7 +888,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const overlay   = document.getElementById('dashboard-welcome-overlay');
   const modal     = document.getElementById('dashboard-welcome-modal');
   const cbDont    = document.getElementById('dw-dont-show');
-  const cbWelM    = document.getElementById('dw-enable-welcome');
   const cbTourM   = document.getElementById('dw-enable-tour');
   const btnSaveM  = document.getElementById('dw-save');
   const btnStartM = document.getElementById('dw-start');
@@ -926,7 +925,6 @@ document.addEventListener('DOMContentLoaded', () => {
   // --- View sync ---
   function syncModalFromPrefs(){
     const p = getPrefs();
-    if (cbWelM)  cbWelM.checked  = p.welcomeEnabled;
     if (cbTourM) cbTourM.checked = p.tourEnabled;
     if (cbDont)  cbDont.checked  = p.welcomeDone;
   }
@@ -942,7 +940,6 @@ document.addEventListener('DOMContentLoaded', () => {
   // --- Persist from UI (Modal) ---
   function persistFromModal({lockDone=false} = {}){
     const next = {};
-    if (cbWelM)  next.welcomeEnabled = !!cbWelM.checked;
     if (cbTourM) next.tourEnabled    = !!cbTourM.checked;
     if (lockDone && cbDont) next.welcomeDone = !!cbDont.checked;
     setPrefs(next);
@@ -961,7 +958,6 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   // AUTOSAVE on checkbox changes (both places), so choices “stick” even if user closes without pressing Save
-  cbWelM?.addEventListener('change', () => persistFromModal());
   cbTourM?.addEventListener('change', () => persistFromModal());
   cbDont?.addEventListener('change', () => persistFromModal({lockDone:true}));
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -1121,3 +1121,5 @@ button {
   background: #1e1e1e; color: #fff; padding: 6px 10px; border-radius: 8px; cursor: pointer;
 }
 .siq-tour-btn.primary { background: #2a6df4; border-color: #2a6df4; }
+
+.tooltip, .help-tooltip, .help-bubble { display: none !important; }

--- a/public/tally.html
+++ b/public/tally.html
@@ -742,11 +742,10 @@ document.addEventListener('DOMContentLoaded', () => {
 <div id="tally-onboard-overlay" role="dialog" aria-modal="true" aria-labelledby="tally-onboard-title" aria-hidden="true">
   <div id="tally-onboard-dialog">
     <h2 id="tally-onboard-title">Welcome to the SHEΔR iQ Tally Tour</h2>
-    <p>This quick tour will show you the key parts of the tally page and how to use them. You can skip it anytime — you’ll still be able to hover or long-press fields for tips later.</p>
-    <p>You can also enable or disable tooltips and the guided tour. These settings can be changed anytime from the Help menu (the “?” button).</p>
+    <p>This quick tour will show you the key parts of the tally page and how to use them. You can skip it anytime and revisit the guided tour later from the Help menu.</p>
+    <p>You can enable or disable the guided tour anytime from the Help menu (the “?” button).</p>
 
     <form id="tally-onboard-form">
-      <label><input type="checkbox" id="onboard-tooltips"> Enable tooltips</label>
       <label><input type="checkbox" id="onboard-tour"> Enable guided tour</label>
       <div class="form-row" style="margin-top:12px">
         <label>
@@ -769,7 +768,6 @@ document.addEventListener('DOMContentLoaded', () => {
 <script>
 (function(){
   const overlay = document.getElementById('tally-onboard-overlay');
-  const tips = document.getElementById('onboard-tooltips');
   const tour = document.getElementById('onboard-tour');
   const disableSetup = document.getElementById('disableSetupModalChk');
   const saveStart = document.getElementById('onboard-save-start');
@@ -778,11 +776,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const skip = document.getElementById('onboard-skip');
 
   const gb = k => (localStorage.getItem(k) ?? 'true') === 'true';
-  const sb = (k,v) => localStorage.setItem(k, v ? 'true' : 'false');
 
   function openModal(){
     if (localStorage.getItem('tally_onboard_seen') === 'true') return;
-    tips.checked = gb('tooltips_enabled');
     tour.checked = gb('tally_guide_enabled');
     if (disableSetup) disableSetup.checked = (isSetupModalEnabled() === false);
     overlay.classList.add('show');
@@ -800,11 +796,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function saveChoices(){
     // persist to storage
-    localStorage.setItem('tooltips_enabled', tips.checked ? 'true' : 'false');
     localStorage.setItem('tally_guide_enabled', tour.checked ? 'true' : 'false');
 
-    // NEW: update runtime flags immediately (safe if functions don’t exist)
-    try { if (typeof window.setTipsEnabled  === 'function') window.setTipsEnabled(!!tips.checked); } catch(e){}
+    // NEW: update runtime flag immediately (safe if function doesn’t exist)
     try { if (typeof window.setGuideEnabled === 'function') window.setGuideEnabled(!!tour.checked); } catch(e){}
 
     if (disableSetup) setSetupModalEnabled(!disableSetup.checked);

--- a/public/tally.js
+++ b/public/tally.js
@@ -41,7 +41,6 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 // === HELP MENU GLOBALS ===
-if (localStorage.getItem('tooltips_enabled') == null) localStorage.setItem('tooltips_enabled','true');
 if (localStorage.getItem('tally_guide_enabled') == null) localStorage.setItem('tally_guide_enabled','true');
 if (localStorage.getItem('setup_modal_enabled') == null){
   localStorage.setItem('setup_modal_enabled', 'true');
@@ -50,7 +49,7 @@ if (localStorage.getItem('hours_modal_enabled') == null) localStorage.setItem('h
 
 // ===== Help/Tour global runtime state (safe default) =====
 window.TT_STATE = window.TT_STATE || {
-  tooltipsEnabled: (localStorage.getItem('tooltips_enabled') ?? 'true') === 'true',
+  tooltipsEnabled: false,
   guideEnabled:    (localStorage.getItem('tally_guide_enabled') ?? 'true') === 'true',
 };
 
@@ -71,9 +70,6 @@ window.renderHelpMenu = function () {
       <strong>Help</strong><button id="ttx" style="padding:6px 10px;">✕</button>
     </div>
     <label style="display:block;margin:8px 0;">
-      <input id="tips" type="checkbox"> Enable tooltips
-    </label>
-    <label style="display:block;margin:8px 0;">
       <input id="tour" type="checkbox"> Enable guided tour
     </label>
     <label style="display:block;margin:8px 0;">
@@ -83,7 +79,6 @@ window.renderHelpMenu = function () {
   `;
   const gb = k => (localStorage.getItem(k) ?? 'true') === 'true';
   const sb = (k,v) => localStorage.setItem(k, v ? 'true' : 'false');
-  const tips = m.querySelector('#tips');
   const tour = m.querySelector('#tour');
   const hoursModalToggle = m.querySelector('#hoursModalToggle');
   const start = m.querySelector('#start');
@@ -102,10 +97,8 @@ window.renderHelpMenu = function () {
       setSetupModalEnabled(toggleSetupBox.checked);
     });
   }
-  tips.checked = gb('tooltips_enabled');
   tour.checked  = gb('tally_guide_enabled');
   if (hoursModalToggle) hoursModalToggle.checked = gb('hours_modal_enabled');
-  tips.onchange = () => window.setTipsEnabled(tips.checked);
   tour.onchange = () => window.setGuideEnabled(tour.checked);
   if (hoursModalToggle) hoursModalToggle.onchange = () => sb('hours_modal_enabled', hoursModalToggle.checked);
   start.onclick  = () => { if (tour.checked && typeof window.startGuide === 'function') window.startGuide(); };
@@ -3116,7 +3109,7 @@ function initTallyTooltips() {
   }
 
   function showTooltip(target, text) {
-    if (!window.TT_STATE.tooltipsEnabled) return;
+    if (!isGuidedActive()) return;
     if (!text || !String(text).trim()) { hideTooltip(); return; }
     const tt = document.getElementById('tt-root');
     if (isGuidedActive()) {
@@ -3133,6 +3126,7 @@ function initTallyTooltips() {
   }
 
   function hideTooltip() {
+    if (!isGuidedActive()) return;
     const tt = document.getElementById('tt-root');
     tt.setAttribute('aria-hidden', 'true');
     tt.classList.remove('tt-show');
@@ -3212,8 +3206,8 @@ function initTallyTooltips() {
   function endGuided() {
     guidedMode = false;
     tt.classList.remove('guided');
-    window.__tt_guidedActive = false;
     hideTooltip();
+    window.__tt_guidedActive = false;
     clearHighlight();
   }
 
@@ -3233,48 +3227,6 @@ function initTallyTooltips() {
     showGuidedStep();
   }
 
-  // Show on first entry into a qualifying element
-  document.addEventListener('mouseover', (e) => {
-    if (!window.TT_STATE.tooltipsEnabled || isGuidedActive()) return;
-    const t = findTipTarget(e.target);
-    if (!t || t === currentTipTarget) return;
-
-    // New target: show tip and set up a one-off stable leave handler on the element itself
-    currentTipTarget = t;
-    showTooltip(t, getHelpText(t));
-
-    // Clean up any prior leave handler
-    if (currentLeaveHandler) {
-      try { currentTipTarget.removeEventListener('mouseleave', currentLeaveHandler, true); } catch {}
-    }
-    currentLeaveHandler = () => {
-      if (shouldSuppressAutoHide()) return;
-      hideTooltip();
-      currentTipTarget?.removeEventListener('mouseleave', currentLeaveHandler, true);
-      currentTipTarget = null;
-      currentLeaveHandler = null;
-    };
-    t.addEventListener('mouseleave', currentLeaveHandler, true);
-  }, true);
-
-  // We no longer use document-level mouseout for hiding (prevents flicker)
-
-  // Keyboard: show on focus, hide on blur
-  document.addEventListener('focusin', (e) => {
-    if (!window.TT_STATE.tooltipsEnabled || isGuidedActive()) return;
-    const t = findTipTarget(e.target);
-    if (!t) return;
-    currentTipTarget = t;
-    showTooltip(t, getHelpText(t));
-  }, true);
-
-  document.addEventListener('focusout', (e) => {
-    if (!window.TT_STATE.tooltipsEnabled) return;
-    if (shouldSuppressAutoHide()) return;
-    if (currentTipTarget && !currentTipTarget.contains(e.relatedTarget)) {
-      hideTooltip(); currentTipTarget = null; currentLeaveHandler = null;
-    }
-  }, true);
   function showGuideDisabledToast() {
     let toast = document.getElementById('tt-disabled-toast');
     if (!toast) {
@@ -3289,14 +3241,6 @@ function initTallyTooltips() {
   }
 
   // ===== Public setters: keep storage AND runtime in sync, then notify =====
-  window.setTipsEnabled = function setTipsEnabled(enabled) {
-    const v = !!enabled;
-    localStorage.setItem('tooltips_enabled', v ? 'true' : 'false');
-    window.TT_STATE.tooltipsEnabled = v;
-    if (!v) hideTooltip();
-    document.dispatchEvent(new CustomEvent('help-flags-changed', { detail: { tooltips: v, guide: window.TT_STATE.guideEnabled }}));
-  };
-
   window.setGuideEnabled = function setGuideEnabled(enabled) {
     const v = !!enabled;
     localStorage.setItem('tally_guide_enabled', v ? 'true' : 'false');
@@ -3341,47 +3285,11 @@ function initTallyTooltips() {
     });
   }
 
-  let touchTimer = null;
-  document.addEventListener('touchstart', (e) => {
-    if (!window.TT_STATE.tooltipsEnabled || isGuidedActive()) return;
-    const t = findTipTarget(e.target);
-    if (!t) { if (!shouldSuppressAutoHide()) hideTooltip(); return; }
-    touchTimer = setTimeout(() => { showTooltip(t, getHelpText(t)); }, 500);
-  }, { passive: true });
-  function clearTouch() { if (touchTimer) { clearTimeout(touchTimer); touchTimer = null; } }
-  document.addEventListener('touchend', () => {
-    clearTouch();
-    if (!window.TT_STATE.tooltipsEnabled || Date.now() - guidedStartTs < 500 || shouldSuppressAutoHide()) return;
-    setTimeout(() => {
-      if (!window.TT_STATE.tooltipsEnabled || shouldSuppressAutoHide()) return;
-      hideTooltip();
-      currentTipTarget = null;
-      currentLeaveHandler = null;
-    }, 1000);
-  }, { passive: true });
-  document.addEventListener('touchcancel', () => {
-    clearTouch();
-    if (!window.TT_STATE.tooltipsEnabled || shouldSuppressAutoHide()) return;
-    hideTooltip();
-  }, { passive: true });
-
-  window.addEventListener('scroll', () => {
-    if (shouldSuppressAutoHide()) {
-      if (currentTarget) positionTooltip(currentTarget);
-    } else if (window.TT_STATE.tooltipsEnabled) {
-      hideTooltip();
-    }
-  }, { capture: true, passive: true });
-  window.addEventListener('resize', () => { if (isGuidedActive() && currentTarget) positionTooltip(currentTarget); });
-  document.addEventListener('keydown', e => { if (e.key === 'Escape') { if (shouldSuppressAutoHide() || !window.TT_STATE.tooltipsEnabled) return; hideTooltip(); } });
-  document.addEventListener('keydown', e => {
-    if (!window.TT_STATE.tooltipsEnabled || shouldSuppressAutoHide()) return;
-    if (e.target && (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA')) hideTooltip();
-  }, true);
-
   window.showTooltip = showTooltip;
   window.hideTooltip = hideTooltip;
   window.startGuide = startGuide;
+
+  if (false) return;
 }
 
 window.initTallyTooltips = initTallyTooltips;


### PR DESCRIPTION
## Summary
- Remove Setup Day checkbox from contractor welcome modal and related logic
- Strip tooltip preference from tally UI and disable tooltip system
- Hide old tooltip elements with CSS while preserving guided tours

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68a44872030483219777c0ad316af90a