### PR TITLE
feat: add reset to farm summary filters

### DIFF
--- a/public/tally.html
+++ b/public/tally.html
@@ -389,6 +389,7 @@
   </label>
 
   <button id="stationSummaryApply">Apply</button>
+  <button id="stationSummaryReset" type="button">Reset</button>
 </div>
 
 <p id="stationNoData" class="message" style="margin-top:8px;">

--- a/public/tally.js
+++ b/public/tally.js
@@ -1791,6 +1791,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const endEl   = document.getElementById('summaryEnd');
   const allEl   = document.getElementById('summaryAllTime');
   const apply   = document.getElementById('stationSummaryApply');
+  const reset   = document.getElementById('stationSummaryReset');
   const msgEl   = document.getElementById('stationNoData');
 
   // Keep farm list fresh on load (no auto-build)
@@ -1826,6 +1827,17 @@ document.addEventListener('DOMContentLoaded', () => {
       hideMsg();
       // Build summary now that inputs are valid
       if (typeof buildStationSummary === 'function') buildStationSummary();
+    });
+  }
+
+  if (reset) {
+    reset.addEventListener('click', () => {
+      if (farmSel) farmSel.value = '';
+      if (startEl) startEl.value = '';
+      if (endEl) endEl.value = '';
+      if (allEl) allEl.checked = false;
+      if (typeof clearStationSummaryView === 'function') clearStationSummaryView();
+      showMsg('Select a farm and date range, or tick “All time for this farm”, then press Apply.');
     });
   }
 });


### PR DESCRIPTION
## Summary
- add Reset button to Farm Summary filters
- clear farm selection, date range, and summary tables on reset
- display default instruction message after clearing

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a517a9f4f08321a22acaa798e466f5