### PR TITLE
Fix shed-staff hours wrapping

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1146,3 +1146,20 @@ button {
   text-align: right;        /* keep it flush-right like the shearers widget */
 }
 
+/* Shed Staff widget: keep hours on one line and size sanely on all screens */
+#top5-shedstaff .siq-lb-value {
+  white-space: nowrap;                       /* never wrap */
+  line-height: 1.1;                          /* compact line box */
+  font-size: clamp(0.80rem, 1.6vw, 0.92rem); /* a bit smaller than default */
+  text-align: right;                         /* align like shearers */
+}
+
+/* Give the number column more room so long labels don’t wrap */
+#top5-shedstaff .siq-lb-row {
+  grid-template-columns: 24px 1fr 70px;      /* widen value column */
+}
+
+/* Optional: extra protection for very narrow phones */
+@media (max-width: 340px){
+  #top5-shedstaff .siq-lb-value { font-size: 0.80rem; }
+}


### PR DESCRIPTION
## Summary
- Prevent wrapping of shed-staff hours by sizing and aligning the value consistently across viewports
- Widen the shed-staff widget value column and add protective media query for very narrow phones

## Testing
- `npm test` *(fails: Missing script "test")*

## Manual Testing
- Hard reload the dashboard (DevTools → right-click refresh → Empty Cache and Hard Reload)
- Verify the shed-staff hours (e.g., “8h 15m”) are on one line at widths ~340px, 360px, 400px, 768px, and desktop


------
https://chatgpt.com/codex/tasks/task_e_68a51b5676608321bd7db1b1c317d019