### PR TITLE
feat: add paginated session list with filters

### DIFF
--- a/public/view-sessions.html
+++ b/public/view-sessions.html
@@ -30,9 +30,40 @@
     <div class="tabs">
       <button id="backToDashboard" class="tab-button" style="display: none;">Return to Dashboard</button>
     </div>
-    <div id="sessionList">
-      <!-- Sessions will be loaded here -->
+
+    <!-- Filters + controls -->
+    <div id="sessionFilters" style="display:flex;gap:8px;align-items:end;margin:10px 0;flex-wrap:wrap;">
+      <label>
+        <div style="font-size:12px;opacity:.8;">Search (Station)</div>
+        <input id="sfq" type="text" placeholder="Type to filter…" style="padding:6px;min-width:200px;">
+      </label>
+      <label>
+        <div style="font-size:12px;opacity:.8;">From</div>
+        <input id="sfrom" type="date" style="padding:6px;">
+      </label>
+      <label>
+        <div style="font-size:12px;opacity:.8;">To</div>
+        <input id="sto" type="date" style="padding:6px;">
+      </label>
+      <button id="sapply" class="tab-button" type="button">Apply</button>
+      <button id="sclear" class="tab-button" type="button">Clear</button>
     </div>
+
+    <!-- Expand/Collapse + meta -->
+    <div id="sessionControls" style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin:6px 0 12px;">
+      <button id="expandAll" class="tab-button" type="button">Expand all</button>
+      <button id="collapseAll" class="tab-button" type="button">Collapse all</button>
+      <div id="sessionListMeta" style="opacity:.8;font-size:0.9rem;"></div>
+    </div>
+
+    <!-- Grouped list container -->
+    <div id="sessionListOuter">
+      <!-- JS will create one <section data-year="YYYY"> per year -->
+      <div id="sessionList"><!-- fallback container; stays empty when grouping is used --></div>
+    </div>
+
+    <!-- Load more button -->
+    <button id="loadMoreBtn" class="tab-button" style="margin-top:8px; display:none;">Load more</button>
   </div>
 
   <script>

--- a/public/view-sessions.js
+++ b/public/view-sessions.js
@@ -11,95 +11,237 @@ function formatNZDate(iso) {
   return `${day}/${month}/${year}`;
 }
 
-async function fetchSessions(contractorId) {
-  const listEl = document.getElementById('sessionList');
-  if (!listEl) return;
-  listEl.innerHTML = '';
+// ---- PAGING + STATE ----
+const PAGE_SIZE = 25;
+let _contractorId = null;
+let _lastDoc = null;
+let _reachedEnd = false;
+let _loading = false;
+let _totalLoaded = 0;
+let allSessions = []; // accumulate fetched docs as plain objects { __id, ...data }
+
+// Parse Date from session fields; prefer 'date' then 'savedAt'
+function parseSessionDate(s) {
+  const val = s?.date || s?.savedAt;
+  if (!val) return null;
+  if (typeof val === 'object' && typeof val.toDate === 'function') return val.toDate();
+  const d = new Date(val);
+  return isNaN(d) ? null : d;
+}
+function yKeyFromDate(d) { return d ? String(d.getFullYear()) : 'Unknown'; }
+
+// Ensure a collapsible year section exists and return it
+function ensureYearSection(yearKey) {
+  const outer = document.getElementById('sessionListOuter');
+  if (!outer) return null;
+  let sec = outer.querySelector(`[data-year="${yearKey}"]`);
+  if (sec) return sec;
+
+  sec = document.createElement('section');
+  sec.setAttribute('data-year', yearKey);
+  sec.style.marginBottom = '12px';
+  sec.innerHTML = `
+    <div class="year-header" style="display:flex;justify-content:space-between;align-items:center;cursor:pointer;background:#151515;border:1px solid #333;padding:8px;">
+      <strong>${yearKey}</strong>
+      <span class="chev" aria-hidden="true">▾</span>
+    </div>
+    <div class="year-body" style="border:1px solid #333;border-top:none;padding:8px;"></div>
+  `;
+  const loadMoreBtn = document.getElementById('loadMoreBtn');
+  outer.insertBefore(sec, loadMoreBtn || null);
+
+  // toggle collapse
+  const header = sec.querySelector('.year-header');
+  header.addEventListener('click', () => {
+    const body = sec.querySelector('.year-body');
+    const chev = sec.querySelector('.chev');
+    const isHidden = body.style.display === 'none';
+    body.style.display = isHidden ? '' : 'none';
+    chev.textContent = isHidden ? '▾' : '▸';
+  });
+  return sec;
+}
+function clearYearSections() {
+  const outer = document.getElementById('sessionListOuter');
+  if (!outer) return;
+  [...outer.querySelectorAll('section[data-year]')].forEach(s => s.remove());
+}
+
+// Reuse the existing row look/feel
+function renderSessionRowInto(container, docId, data) {
+  const station = data.stationName || 'Unnamed Station';
+  const dateStr = formatNZDate(data.date || data.savedAt);
+  const totalSheep = Array.isArray(data.shearerCounts)
+    ? data.shearerCounts.reduce((sum, r) => sum + (parseInt(r.total, 10) || 0), 0)
+    : 0;
+  const shearers = Array.isArray(data.stands) ? data.stands.length : 0;
+  const shedStaff = Array.isArray(data.shedStaff) ? data.shedStaff.length : 0;
+
+  const row = document.createElement('div');
+  row.style.display = 'flex';
+  row.style.justifyContent = 'space-between';
+  row.style.alignItems = 'center';
+  row.style.padding = '10px';
+  row.style.marginBottom = '10px';
+  row.style.border = '1px solid #333';
+  row.style.background = '#111';
+
+  const info = document.createElement('div');
+  info.innerHTML = `
+    <strong>${station}</strong><br>
+    ${dateStr || ''}<br>
+    🐑 ${totalSheep} | Shearers: ${shearers} | Shed Staff: ${shedStaff}
+  `;
+  row.appendChild(info);
+
+  const btns = document.createElement('div');
+
+  const viewBtn = document.createElement('button');
+  viewBtn.textContent = 'View';
+  viewBtn.className = 'tab-button';
+  viewBtn.addEventListener('click', () => {
+    localStorage.setItem('active_session', JSON.stringify(data));
+    localStorage.setItem('firestoreSessionId', docId);
+    localStorage.setItem('viewOnlyMode', 'true');
+    window.location.href = 'tally.html?loadedSession=true';
+  });
+  btns.appendChild(viewBtn);
+
+  const editBtn = document.createElement('button');
+  editBtn.textContent = 'Edit';
+  editBtn.className = 'tab-button';
+  editBtn.style.marginLeft = '6px';
+  editBtn.addEventListener('click', () => {
+    const pin = prompt('\uD83D\uDD10 Enter Contractor PIN to edit:');
+    if (pin === '1234') {
+      const editable = { ...data, viewOnly: false };
+      localStorage.setItem('active_session', JSON.stringify(editable));
+      localStorage.setItem('firestoreSessionId', docId);
+      localStorage.setItem('viewOnlyMode', 'false');
+      window.location.href = 'tally.html?loadedSession=true';
+    } else if (pin !== null) {
+      alert('Incorrect PIN');
+    }
+  });
+  btns.appendChild(editBtn);
+
+  row.appendChild(btns);
+  container.appendChild(row);
+}
+
+function updateMetaAndButton() {
+  const meta = document.getElementById('sessionListMeta');
+  const btn = document.getElementById('loadMoreBtn');
+  if (meta) {
+    meta.textContent = _totalLoaded
+      ? `Loaded ${_totalLoaded} session${_totalLoaded === 1 ? '' : 's'}`
+      : '';
+  }
+  if (btn) {
+    if (_reachedEnd) {
+      btn.style.display = _totalLoaded ? 'none' : 'inline-block';
+      btn.disabled = true;
+      btn.textContent = _totalLoaded ? 'Load more' : 'No sessions found';
+    } else {
+      btn.style.display = 'inline-block';
+      btn.disabled = _loading;
+      btn.textContent = _loading ? 'Loading…' : 'Load more';
+    }
+  }
+}
+
+function applyFiltersAndRender() {
+  const q = (document.getElementById('sfq')?.value || '').trim().toLowerCase();
+  const fromV = document.getElementById('sfrom')?.value || '';
+  const toV   = document.getElementById('sto')?.value || '';
+  const from = fromV ? new Date(fromV + 'T00:00:00') : null;
+  const to   = toV   ? new Date(toV   + 'T23:59:59') : null;
+
+  const rows = allSessions.filter(s => {
+    const station = (s.stationName || '').toLowerCase();
+    if (q && !station.includes(q)) return false;
+    const dt = parseSessionDate(s);
+    if (from && (!dt || dt < from)) return false;
+    if (to && (!dt || dt > to)) return false;
+    return true;
+  });
+
+  // Clear grouped UI and fallback container
+  clearYearSections();
+  const fallback = document.getElementById('sessionList');
+  if (fallback) fallback.innerHTML = '';
+
+  if (!rows.length) {
+    if (fallback) fallback.innerHTML = '<p>No sessions match your filter.</p>';
+    return;
+  }
+
+  // Newest first within groups
+  rows.sort((a, b) => {
+    const da = parseSessionDate(a)?.getTime() || 0;
+    const db = parseSessionDate(b)?.getTime() || 0;
+    return db - da;
+  });
+
+  for (const s of rows) {
+    const d = parseSessionDate(s);
+    const yKey = yKeyFromDate(d);
+    const sec = ensureYearSection(yKey);
+    const body = sec?.querySelector('.year-body');
+    if (!body) continue;
+    renderSessionRowInto(body, s.__id, s);
+  }
+}
+
+async function loadNextPage() {
+  if (_loading || _reachedEnd || !_contractorId) return;
+  _loading = true;
+  updateMetaAndButton();
 
   try {
-    const snap = await firebase
+    let q = firebase
       .firestore()
       .collection('contractors')
-      .doc(contractorId)
+      .doc(_contractorId)
       .collection('sessions')
       .orderBy('date', 'desc')
-      .get();
+      .limit(PAGE_SIZE);
 
+    if (_lastDoc) q = q.startAfter(_lastDoc);
+
+    const snap = await q.get();
     if (snap.empty) {
-      const msg = document.createElement('p');
-      msg.textContent = 'No sessions found.';
-      listEl.appendChild(msg);
+      if (_totalLoaded === 0) {
+        const fallback = document.getElementById('sessionList');
+        if (fallback) fallback.innerHTML = '<p>No sessions found.</p>';
+      }
+      _reachedEnd = true;
       return;
     }
 
+    _lastDoc = snap.docs[snap.docs.length - 1];
+
     snap.forEach(doc => {
       const data = doc.data() || {};
-      const station = data.stationName || 'Unnamed Station';
-      const dateStr = formatNZDate(data.date);
-      const totalSheep = Array.isArray(data.shearerCounts)
-        ? data.shearerCounts.reduce((sum, r) => sum + (parseInt(r.total, 10) || 0), 0)
-        : 0;
-      const shearers = Array.isArray(data.stands) ? data.stands.length : 0;
-      const shedStaff = Array.isArray(data.shedStaff) ? data.shedStaff.length : 0;
-
-      const row = document.createElement('div');
-      row.style.display = 'flex';
-      row.style.justifyContent = 'space-between';
-      row.style.alignItems = 'center';
-      row.style.padding = '10px';
-      row.style.marginBottom = '10px';
-      row.style.border = '1px solid #333';
-      row.style.background = '#111';
-
-      const info = document.createElement('div');
-      info.innerHTML = `
-        <strong>${station}</strong><br>
-        ${dateStr}<br>
-        🐑 ${totalSheep} | Shearers: ${shearers} | Shed Staff: ${shedStaff}
-      `;
-      row.appendChild(info);
-
-      const btns = document.createElement('div');
-
-      const viewBtn = document.createElement('button');
-      viewBtn.textContent = 'View';
-      viewBtn.className = 'tab-button';
-      viewBtn.addEventListener('click', () => {
-        // Save session data and ID to localStorage
-        localStorage.setItem('active_session', JSON.stringify(data));
-        localStorage.setItem('firestoreSessionId', doc.id);
-        localStorage.setItem('viewOnlyMode', 'true');
-        // Redirect to tally page with loadedSession flag
-        window.location.href = 'tally.html?loadedSession=true';
-      });
-      btns.appendChild(viewBtn);
-
-      const editBtn = document.createElement('button');
-      editBtn.textContent = 'Edit';
-      editBtn.className = 'tab-button';
-      editBtn.style.marginLeft = '6px';
-      editBtn.addEventListener('click', () => {
-        const pin = prompt('\uD83D\uDD10 Enter Contractor PIN to edit:');
-        if (pin === '1234') {
-          const editable = { ...data, viewOnly: false };
-          localStorage.setItem('active_session', JSON.stringify(editable));
-          localStorage.setItem('firestoreSessionId', doc.id);
-          localStorage.setItem('viewOnlyMode', 'false');
-          window.location.href = 'tally.html?loadedSession=true';
-        } else if (pin !== null) {
-          alert('Incorrect PIN');
-        }
-      });
-      btns.appendChild(editBtn);
-
-      row.appendChild(btns);
-      listEl.appendChild(row);
+      allSessions.push({ __id: doc.id, ...data });
+      _totalLoaded++;
     });
+
+    applyFiltersAndRender();
+
+    if (snap.size < PAGE_SIZE) {
+      _reachedEnd = true;
+    }
   } catch (err) {
-    console.error('Failed to load sessions', err);
-    const msg = document.createElement('p');
-    msg.textContent = 'Error loading sessions.';
-    listEl.appendChild(msg);
+    console.error('Failed to load sessions page', err);
+    if (_totalLoaded === 0) {
+      const fallback = document.getElementById('sessionList');
+      if (fallback) fallback.innerHTML = '<p>Error loading sessions.</p>';
+    }
+    _reachedEnd = true;
+  } finally {
+    _loading = false;
+    updateMetaAndButton();
   }
 }
 
@@ -122,8 +264,19 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       const contractorId = doc.id;
       localStorage.setItem('contractor_id', contractorId);
-      await fetchSessions(contractorId);
 
+      // Reset paging state
+      _contractorId = contractorId;
+      _lastDoc = null;
+      _reachedEnd = false;
+      _loading = false;
+      _totalLoaded = 0;
+      allSessions = [];
+
+      // First page
+      await loadNextPage();
+
+      // Reveal page + Return to Dashboard handler (keep existing)
       const page = document.getElementById('page-content');
       if (page) page.style.display = 'block';
       const dashBtn = document.getElementById('backToDashboard');
@@ -133,6 +286,40 @@ document.addEventListener('DOMContentLoaded', () => {
           window.location.href = 'dashboard.html';
         });
       }
+
+      // Wire filters and controls
+      const sfq   = document.getElementById('sfq');
+      const sfrom = document.getElementById('sfrom');
+      const sto   = document.getElementById('sto');
+      const sapply= document.getElementById('sapply');
+      const sclear= document.getElementById('sclear');
+      const more  = document.getElementById('loadMoreBtn');
+      const exAll = document.getElementById('expandAll');
+      const colAll= document.getElementById('collapseAll');
+
+      function applyNow(){ applyFiltersAndRender(); }
+
+      sapply?.addEventListener('click', applyNow);
+      sclear?.addEventListener('click', () => {
+        if (sfq)   sfq.value = '';
+        if (sfrom) sfrom.value = '';
+        if (sto)   sto.value = '';
+        applyFiltersAndRender();
+      });
+      // Optional: live typing search
+      sfq?.addEventListener('input', applyNow);
+
+      more?.addEventListener('click', () => loadNextPage());
+
+      exAll?.addEventListener('click', () => {
+        document.querySelectorAll('section[data-year] .year-body').forEach(b => b.style.display = '');
+        document.querySelectorAll('section[data-year] .chev').forEach(c => c.textContent = '▾');
+      });
+      colAll?.addEventListener('click', () => {
+        document.querySelectorAll('section[data-year] .year-body').forEach(b => b.style.display = 'none');
+        document.querySelectorAll('section[data-year] .chev').forEach(c => c.textContent = '▸');
+      });
+
     } catch (err) {
       console.error('Failed to verify contractor', err);
       window.location.replace('login.html');


### PR DESCRIPTION
## Summary
- add station search, date filters, and expand/collapse controls
- group sessions by year with collapsible sections
- load sessions in 25-item pages with a load more button

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a51fa8301883218c732e3dad4dbb30