### PR TITLE
Compact date previews with modal

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1163,3 +1163,14 @@ button {
 @media (max-width: 340px){
   #top5-shedstaff .siq-lb-value { font-size: 0.80rem; }
 }
+
+/* Link-style button for viewing full date lists */
+.view-dates-btn {
+  background: transparent;
+  border: none;
+  color: #2f81f7;
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 0;
+  font: inherit;
+}

--- a/public/tally.html
+++ b/public/tally.html
@@ -635,7 +635,18 @@ document.addEventListener('DOMContentLoaded', function () {
   </div>
 </div>
 
-  <div id="autosaveStatus" style="display:none; position:fixed; bottom:10px; right:10px; background:#222; color:#fff; padding:4px 8px; border-radius:4px; font-size:14px;"></div>
+<!-- Date List Modal -->
+<div id="dateListModal" class="modal-overlay" style="display:none;">
+  <div class="modal-box">
+    <h3>All Dates</h3>
+    <div id="dateListContent" style="max-height:200px; overflow-y:auto; text-align:left;"></div>
+    <div class="modal-buttons" style="margin-top:10px;">
+      <button id="dateListCloseBtn">Close</button>
+    </div>
+  </div>
+</div>
+
+<div id="autosaveStatus" style="display:none; position:fixed; bottom:10px; right:10px; background:#222; color:#fff; padding:4px 8px; border-radius:4px; font-size:14px;"></div>
 <div id="hours-modal" class="hours-modal" aria-hidden="true">
   <div class="hours-modal-content">
     <p>Hours Worked automatically fills from Start and Finish times.</p>


### PR DESCRIPTION
## Summary
- show compact date ranges for team leaders and comb types
- add modal with full date lists and link-style buttons

## Testing
- `npm test` *(fails: missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a522f9a428832183715182a60fa7f4