### PR TITLE
Ensure load-more button stays inside session list container

### DIFF
--- a/public/view-sessions.html
+++ b/public/view-sessions.html
@@ -60,10 +60,10 @@
     <div id="sessionListOuter">
       <!-- JS will create one <section data-year="YYYY"> per year -->
       <div id="sessionList"><!-- fallback container; stays empty when grouping is used --></div>
-    </div>
 
-    <!-- Load more button -->
-    <button id="loadMoreBtn" class="tab-button" style="margin-top:8px; display:none;">Load more</button>
+      <!-- Load more button MUST live inside this outer container -->
+      <button id="loadMoreBtn" class="tab-button" style="margin-top:8px; display:none;">Load more</button>
+    </div>
   </div>
 
   <script>

--- a/public/view-sessions.js
+++ b/public/view-sessions.js
@@ -48,7 +48,11 @@ function ensureYearSection(yearKey) {
     <div class="year-body" style="border:1px solid #333;border-top:none;padding:8px;"></div>
   `;
   const loadMoreBtn = document.getElementById('loadMoreBtn');
-  outer.insertBefore(sec, loadMoreBtn || null);
+  if (loadMoreBtn && loadMoreBtn.parentNode === outer) {
+    outer.insertBefore(sec, loadMoreBtn);
+  } else {
+    outer.appendChild(sec);
+  }
 
   // toggle collapse
   const header = sec.querySelector('.year-header');
@@ -285,6 +289,13 @@ document.addEventListener('DOMContentLoaded', () => {
         dashBtn.addEventListener('click', () => {
           window.location.href = 'dashboard.html';
         });
+      }
+
+      // Ensure "Load more" lives inside #sessionListOuter (auto-fix if needed)
+      const outer = document.getElementById('sessionListOuter');
+      const moreBtn = document.getElementById('loadMoreBtn');
+      if (outer && moreBtn && moreBtn.parentNode !== outer) {
+        outer.appendChild(moreBtn);
       }
 
       // Wire filters and controls


### PR DESCRIPTION
## Summary
- Move "Load more" button inside the session list container in view-sessions.html
- Safely insert year sections before the button only when it's a child of the container
- Auto-relocate "Load more" button at runtime if misplaced

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5270b4258832182d33ca54e446c99