### PR TITLE
Add guided help for summary views

### DIFF
--- a/public/tally.html
+++ b/public/tally.html
@@ -192,8 +192,8 @@
 
    <div id="tabNav" class="tabs">
   <button class="tab-button active" data-view="tallySheetView">Tally Sheet</button>
-  <button class="tab-button" data-view="summaryView">Daily Summary</button>
-  <button class="tab-button" data-view="stationSummaryView">Farm Summary</button>
+  <button class="tab-button" data-view="summaryView" data-help="View today's totals for the current session.">Daily Summary</button>
+  <button class="tab-button" data-view="stationSummaryView" data-help="See totals for a farm across a date range or all time.">Farm Summary</button>
   <button id="back-to-dashboard-btn" class="tab-button" style="display: none;" data-help="Go back to the Contractor Dashboard.">Return to Dashboard</button>
   </div>
 <div id="tallySheetView" class="view">
@@ -350,8 +350,8 @@
       <img src="logo.png" alt="SHEΔR iQ logo" />
       <h2>Tally Processor</h2>
   </div>
-  <h3 id="summaryTitle" style="margin-top: 10px;"></h3>
-  <table id="summaryTable">
+  <h3 id="summaryTitle" style="margin-top: 10px;" data-help="Title shows the farm and date for this summary."></h3>
+  <table id="summaryTable" data-help="Totals per shearer for the selected day.">
     <thead>
       <tr></tr>
     </thead>
@@ -363,7 +363,7 @@
       <thead>
         <tr><th>Name</th><th>Hours Worked</th></tr>
       </thead>
-      <tbody id="summaryShedStaff"></tbody>
+      <tbody id="summaryShedStaff" data-help="Shed staff and their hours today."></tbody>
     </table>
   </div>
 </div>
@@ -375,48 +375,48 @@
   </div>
   <div class="filters">
   <label for="stationSelect">Farm:</label>
-  <select id="stationSelect" class="small-input"></select>
+  <select id="stationSelect" class="small-input" data-help="Choose the farm to summarise."></select>
 
   <label for="summaryStart">Start Date:</label>
-  <input id="summaryStart" type="date" />
+  <input id="summaryStart" type="date" data-help="Start date for the summary range." />
 
   <label for="summaryEnd">End Date:</label>
-  <input id="summaryEnd" type="date" />
+  <input id="summaryEnd" type="date" data-help="End date for the summary range." />
 
   <label style="display:inline-flex;align-items:center;gap:6px;margin-left:10px;">
-    <input type="checkbox" id="summaryAllTime" />
+    <input type="checkbox" id="summaryAllTime" data-help="Ignore dates and show all data for this farm." />
     All time for this farm
   </label>
 
-  <button id="stationSummaryApply">Apply</button>
-  <button id="stationSummaryReset" type="button">Reset</button>
+  <button id="stationSummaryApply" data-help="Generate the farm summary for these filters.">Apply</button>
+  <button id="stationSummaryReset" type="button" data-help="Clear filters and results.">Reset</button>
 </div>
 
 <p id="stationNoData" class="message" style="margin-top:8px;">
   Select a farm and date range, or tick “All time for this farm”, then press Apply.
 </p>
   <h3>Shearer Summary</h3>
-  <table id="stationShearerTable">
+  <table id="stationShearerTable" data-help="Totals per shearer for the selected farm and dates.">
     <thead><tr></tr></thead>
     <tbody></tbody>
   </table>
   <h3>Shed Staff</h3>
-  <table id="stationStaffTable">
+  <table id="stationStaffTable" data-help="Shed staff hours for the selected range.">
     <thead><tr><th>Name</th><th>Hours Worked</th></tr></thead>
     <tbody></tbody>
   </table>
   <h3>Team Leaders</h3>
-  <table id="stationLeaderTable">
+  <table id="stationLeaderTable" data-help="Team leader totals and dates led.">
     <thead><tr><th>Name</th><th>Total Sheep</th><th>Dates Led</th></tr></thead>
     <tbody></tbody>
   </table>
   <h3>Comb Types</h3>
-  <table id="stationCombTable">
+  <table id="stationCombTable" data-help="Comb types used and when.">
     <thead><tr><th>Comb Type</th><th>Dates Used</th></tr></thead>
     <tbody></tbody>
   </table>
   <h3>Totals</h3>
-  <table id="stationTotalTable">
+  <table id="stationTotalTable" data-help="Overall totals for the farm.">
     <thead><tr></tr></thead>
     <tbody></tbody>
   </table>

--- a/public/tally.js
+++ b/public/tally.js
@@ -3460,7 +3460,7 @@ function initTallyTooltips() {
       endGuided();
       return;
     }
-    guidedList = Array.from(document.querySelectorAll('#tallySheetView [data-help]')).filter(el => el.offsetParent !== null && !el.disabled);
+    guidedList = Array.from(document.querySelectorAll('#tallySheetView [data-help], #summaryView [data-help], #stationSummaryView [data-help]')).filter(el => el.offsetParent !== null && !el.disabled);
     if (!guidedList.length) return;
     guidedMode = true;
     guidedIndex = 0;


### PR DESCRIPTION
## Summary
- describe when to use Daily Summary and Farm Summary tabs
- add tour help for Daily/Farm Summary controls and tables
- extend guided tour to include summary views

## Testing
- `npm install jsdom` *(fails: 403 Forbidden)*
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68a535d633988321ad4dde712e65b160