### PR TITLE
feat: add responsive grid layout for dashboard widgets

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -132,6 +132,7 @@
       </div>
       <div class="dashboard-main">
         <p id="dashboard-subheading"></p>
+        <div id="siq-widgets-grid">
         <!-- BEGIN: Top 5 Shearers Widget -->
         <section id="top5-shearers" class="dash-card top5-widget">
           <header class="dash-card__header">
@@ -159,6 +160,48 @@
             <!-- JS renders 5 rows with bars -->
           </div>
         </section>
+        <!-- BEGIN: Top 5 Shed Staff Widget -->
+        <section id="top5-shedstaff" class="dash-card top5-widget">
+          <header class="dash-card__header">
+            <h2 class="dash-card__title">Top 5 Shed Staff — Hours Worked</h2>
+            <div class="dash-card__controls">
+              <div class="view-select">
+                <label for="shedstaff-view">View</label>
+                <select id="shedstaff-view">
+                  <option value="12m" selected>12M Rolling</option>
+                  <option value="all">All‑Time</option>
+                </select>
+                <select id="shedstaff-year" class="year-select" aria-label="Specific year" hidden></select>
+              </div>
+              <button type="button" id="shedstaff-viewall" class="siq-link-button">View Full List</button>
+            </div>
+          </header>
+
+          <div id="top5-shedstaff-list" class="siq-leaderboard">
+            <!-- JS renders 5 rows with bars -->
+          </div>
+        </section>
+        <!-- BEGIN: Top 5 Farms Widget -->
+        <section id="top5-farms" class="dash-card top5-widget">
+          <header class="dash-card__header">
+            <h2 class="dash-card__title">Top 5 Farms</h2>
+            <div class="dash-card__controls">
+              <div class="view-select">
+                <label for="farms-view">View</label>
+                <select id="farms-view">
+                  <option value="12m" selected>12M Rolling</option>
+                  <option value="all">All‑Time</option>
+                </select>
+                <select id="farms-year" class="year-select" aria-label="Specific year" hidden></select>
+              </div>
+              <button type="button" id="farms-viewall" class="siq-link-button">View All</button>
+            </div>
+          </header>
+          <div id="top5-farms-list" class="siq-leaderboard">
+            <!-- JS renders 5 rows with bars -->
+          </div>
+        </section>
+        </div>
         <!-- Full list modal -->
         <div id="shearers-modal" class="siq-modal" aria-hidden="true">
           <div class="siq-modal__backdrop" data-close-modal></div>
@@ -185,27 +228,6 @@
           </div>
         </div>
         <!-- END: Top 5 Shearers Widget -->
-        <!-- BEGIN: Top 5 Shed Staff Widget -->
-        <section id="top5-shedstaff" class="dash-card top5-widget">
-          <header class="dash-card__header">
-            <h2 class="dash-card__title">Top 5 Shed Staff — Hours Worked</h2>
-            <div class="dash-card__controls">
-              <div class="view-select">
-                <label for="shedstaff-view">View</label>
-                <select id="shedstaff-view">
-                  <option value="12m" selected>12M Rolling</option>
-                  <option value="all">All‑Time</option>
-                </select>
-                <select id="shedstaff-year" class="year-select" aria-label="Specific year" hidden></select>
-              </div>
-              <button type="button" id="shedstaff-viewall" class="siq-link-button">View Full List</button>
-            </div>
-          </header>
-
-          <div id="top5-shedstaff-list" class="siq-leaderboard">
-            <!-- JS renders 5 rows with bars -->
-          </div>
-        </section>
         <!-- Full list modal -->
         <div id="shedstaff-modal" class="siq-modal" aria-hidden="true">
           <div class="siq-modal__backdrop" data-close-modal></div>
@@ -232,26 +254,6 @@
           </div>
         </div>
         <!-- END: Top 5 Shed Staff Widget -->
-        <!-- BEGIN: Top 5 Farms Widget -->
-        <section id="top5-farms" class="dash-card top5-widget">
-          <header class="dash-card__header">
-            <h2 class="dash-card__title">Top 5 Farms</h2>
-            <div class="dash-card__controls">
-              <div class="view-select">
-                <label for="farms-view">View</label>
-                <select id="farms-view">
-                  <option value="12m" selected>12M Rolling</option>
-                  <option value="all">All‑Time</option>
-                </select>
-                <select id="farms-year" class="year-select" aria-label="Specific year" hidden></select>
-              </div>
-              <button type="button" id="farms-viewall" class="siq-link-button">View All</button>
-            </div>
-          </header>
-          <div id="top5-farms-list" class="siq-leaderboard">
-            <!-- JS renders 5 rows with bars -->
-          </div>
-        </section>
         <!-- Full list modal -->
         <div id="farms-full-modal" class="siq-modal" aria-hidden="true">
           <div class="siq-modal__backdrop" data-close-modal></div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1174,3 +1174,54 @@ button {
   padding: 0;
   font: inherit;
 }
+
+/* --- Dashboard responsive grid for the three widgets --- */
+#siq-widgets-grid {
+  display: grid;
+  grid-template-columns: 1fr;   /* phones: 1 column */
+  gap: 16px;
+  align-items: start;
+}
+
+/* tablets: 2 columns */
+@media (min-width: 640px) {
+  #siq-widgets-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+/* desktops: 3 columns */
+@media (min-width: 1024px) {
+  #siq-widgets-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+/* Make each card naturally fill its grid cell height without changing logic */
+#siq-widgets-grid .dash-card,
+#siq-widgets-grid .card,
+#siq-widgets-grid section {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+/* If your cards use a body/content wrapper, let it grow (best-effort, non-breaking) */
+#siq-widgets-grid .dash-card__body,
+#siq-widgets-grid .card-body,
+#siq-widgets-grid .siq-card-body {
+  flex: 1 1 auto;
+  min-height: 0; /* prevent overflow on tight screens */
+}
+
+/* Remove any fixed widths on individual widgets if present (override safely) */
+#top5-shearers, #top5-shedstaff, #top5-farms {
+  max-width: none !important;
+  width: 100%;
+}
+
+/* Optional: tighter gaps on very small phones */
+@media (max-width: 360px) {
+  #siq-widgets-grid { gap: 12px; }
+}


### PR DESCRIPTION
## Summary
- group Top 5 Shearers, Shed Staff, and Farms widgets into new #siq-widgets-grid container
- add responsive grid CSS for 1/2/3-column layout across screen sizes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a53fcffdb88321904a841affcd1c90