### PR TITLE
Ensure shed staff leaderboard rerenders on day changes

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -921,7 +921,9 @@ function initTop5ShedStaffWidget() {
       const mode = (viewSel.value === 'year') ? 'year' : (viewSel.value || '12m');
       const year = (mode === 'year') ? (yearSel.value || new Date().getFullYear()) : null;
         const rows = aggregateStaff(cachedSessions, mode, year);
-        const sig = rows.slice(0,5).map(r => r.name + ':' + Math.round(r.total*60)).join('|');
+        const sig = rows
+          .map(r => `${r.name}:${Math.round(r.total * 60)}:${r.days}`)
+          .join('|');
         if (sig === cachedSig) return;
         cachedSig = sig;
         renderTop5ShedStaff(rows);


### PR DESCRIPTION
## Summary
- Include day counts for every staff row in the shed staff signature to detect any day/hour changes

## Testing
- `node - <<'NODE' ... NODE`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a5430a467c8321bf7d48362d28b8b5