### PR TITLE
Add Top 5 Farms tour step

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1495,6 +1495,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const steps = [
     { sel: '#top5-shearers', text: 'Top 5 Shearers — tap “View Full List” to see rankings.' },
     { sel: '#top5-shedstaff', text: 'Top 5 Shed Staff — see hours worked and days on site.' },
+    { sel: '#top5-farms', text: 'Top 5 Farms — compare farm totals and open “View All”.' },
     { sel: '#btnManageStaff', text: 'Manage Staff — add/remove users and see online status.' },
     { sel: '#farm-summary-btn', text: 'Farm Summary — compare farm totals and visits.' },
     { sel: '#btnViewSavedSessions', text: 'Saved Sessions — reopen previous tally days.' },


### PR DESCRIPTION
## Summary
- expand dashboard tour with Top 5 Farms step guiding users to farm leaderboard

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a556458b1c832190fa6f75f065698f