### PR TITLE
Add Top 5 Farms item to welcome modal

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -312,6 +312,7 @@
       <ul class="dw-list">
         <li><strong>Top 5 Shearers</strong>: See leaders; open “View Full List”.</li>
         <li><strong>Top 5 Shed Staff</strong>: Track hours worked; open “View Full List”.</li>
+        <li><strong>Top 5 Farms</strong>: Compare farm totals; open “View All”.</li>
         <li><strong>Manage Staff</strong>: Add/remove staff; see online/last seen.</li>
         <li><strong>Farm Summary</strong>: Totals and comparisons by farm.</li>
         <li><strong>Saved Sessions</strong>: Reopen past days.</li>


### PR DESCRIPTION
## Summary
- Highlight farm comparisons by adding a “Top 5 Farms” bullet to the dashboard welcome modal

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5564474ac83218a4c9244ae361b3b