### PR TITLE
Add Farm Summary last-N-days date preset

### DIFF
--- a/public/tally.html
+++ b/public/tally.html
@@ -388,6 +388,11 @@
     All time for this farm
   </label>
 
+  <span style="display:inline-flex;align-items:center;gap:6px;margin-left:10px;">
+    <input id="lastNDaysInput" class="small-input" type="number" min="1" value="7" style="width:60px;" data-help="Number of days for the preset." />
+    <button id="lastNDaysBtn" type="button" data-help="Set start and end dates to the last N days.">Last N days</button>
+  </span>
+
   <button id="stationSummaryApply" data-help="Apply the selected filters.">Apply</button>
   <button id="stationSummaryReset" type="button" data-help="Clear the filters.">Reset</button>
 </div>

--- a/public/tally.js
+++ b/public/tally.js
@@ -1859,6 +1859,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const apply   = document.getElementById('stationSummaryApply');
   const reset   = document.getElementById('stationSummaryReset');
   const msgEl   = document.getElementById('stationNoData');
+  const lastNInput = document.getElementById('lastNDaysInput');
+  const lastNBtn   = document.getElementById('lastNDaysBtn');
 
   // Keep farm list fresh on load (no auto-build)
   if (farmSel && typeof populateStationDropdown === 'function') {
@@ -1873,6 +1875,32 @@ document.addEventListener('DOMContentLoaded', () => {
   function hideMsg() {
     if (!msgEl) return;
     msgEl.style.display = 'none';
+  }
+
+  if (lastNBtn) {
+    lastNBtn.addEventListener('click', () => {
+      const n = Math.max(1, parseInt(lastNInput?.value, 10) || 0);
+      const today = new Date();
+      const start = new Date();
+      start.setDate(today.getDate() - (n - 1));
+      const fmt = d => {
+        const y = d.getFullYear();
+        const m = String(d.getMonth() + 1).padStart(2, '0');
+        const day = String(d.getDate()).padStart(2, '0');
+        return `${y}-${m}-${day}`;
+      };
+      if (startEl) startEl.value = fmt(start);
+      if (endEl) endEl.value = fmt(today);
+      if (allEl) allEl.checked = false;
+      const farm = (farmSel?.value || '').trim();
+      if (farm) {
+        hideMsg();
+        apply?.click();
+      } else {
+        if (typeof clearStationSummaryView === 'function') clearStationSummaryView();
+        showMsg('Select a farm and date range, or tick “All time for this farm”, then press Apply.');
+      }
+    });
   }
 
   if (apply) {


### PR DESCRIPTION
## Summary
- add compact last-N-days preset beside Farm Summary "All time" checkbox
- automatically fill dates and apply when a farm is selected

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a557fe7d98832184cd9b995c2022c7