### PR TITLE
Rename Farm Summary Last N days preset to Quick Range

### DIFF
--- a/public/tally.html
+++ b/public/tally.html
@@ -390,7 +390,7 @@
 
   <span style="display:inline-flex;align-items:center;gap:6px;margin-left:10px;">
     <input id="lastNDaysInput" class="small-input" type="number" min="1" value="7" style="width:60px;" data-help="Number of days for the preset." />
-    <button id="lastNDaysBtn" type="button" data-help="Set start and end dates to the last N days.">Last N days</button>
+    <button id="summaryApplyLastN" type="button" title="Quickly set Start/End to the last N days" data-help="Use Quick Range to instantly fill Start and End dates with the last N days. Adjust the number as needed, then click this button.">Quick Range</button>
   </span>
 
   <button id="stationSummaryApply" data-help="Apply the selected filters.">Apply</button>

--- a/public/tally.js
+++ b/public/tally.js
@@ -1860,7 +1860,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const reset   = document.getElementById('stationSummaryReset');
   const msgEl   = document.getElementById('stationNoData');
   const lastNInput = document.getElementById('lastNDaysInput');
-  const lastNBtn   = document.getElementById('lastNDaysBtn');
+  const lastNBtn   = document.getElementById('summaryApplyLastN');
 
   // Keep farm list fresh on load (no auto-build)
   if (farmSel && typeof populateStationDropdown === 'function') {
@@ -3316,6 +3316,7 @@ function initTallyTooltips() {
     '#newDayResetBtn': "Start a new day. Clears today's entries.",
     '#back-to-dashboard-btn': 'Go back to the Contractor Dashboard.',
     '#pin-lock-indicator': 'Past sessions open locked. Contractors can unlock with a PIN.',
+    '#summaryApplyLastN': 'Use Quick Range to instantly fill Start and End dates with the last N days. Adjust the number as needed, then click this button.',
     '#tallyTable': 'Enter tallies by run and stand. Add sheep type for each run.',
     '#sheepTypeTotalsTable': 'Totals by sheep type (auto).'
   };


### PR DESCRIPTION
## Summary
- relabel Farm Summary preset button to "Quick Range" with new tooltip
- explain Quick Range button in help/tour systems

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a55c9e3dac832185cb37d8fcd1614f