### PR TITLE
fix: enhance offline fallback

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,5 +1,5 @@
 // ✅ Bump the cache version whenever you change this file or add new assets
-const CACHE_NAME = 'sheariq-pwa-v7';
+const CACHE_NAME = 'sheariq-pwa-v8';
 
 const FILES_TO_CACHE = [
   // HTML entry points (include the start_url from manifest)
@@ -64,8 +64,8 @@ self.addEventListener('fetch', event => {
           const fresh = await fetch(event.request);
           return fresh;
         } catch (err) {
-          const cached = await caches.match('dashboard.html');
-          return cached || Response.error();
+          const cachedPage = await caches.match(event.request);
+          return cachedPage || await caches.match('dashboard.html') || Response.error();
         }
       })()
     );


### PR DESCRIPTION
## Summary
- improve service worker offline fallback by checking cache for current request before dashboard.html
- bump cache version to v8

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Missing script: "build")*
- `npx firebase deploy --only hosting` *(fails: could not determine executable to run; firebase-tools install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68a5608e2674832194de15f14dd8e650