### PR TITLE
feat: improve offline support

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -93,6 +93,17 @@ try {
 
 import { handleLogout } from './auth.js';
 
+// Unhide content immediately to avoid blank screen offline
+const earlyPage = document.getElementById('page-content');
+if (earlyPage) earlyPage.style.display = 'block';
+
+function showOfflineNotice() {
+  const subheading = document.getElementById('dashboard-subheading');
+  if (subheading) {
+    subheading.textContent = 'Offline mode: limited features available';
+  }
+}
+
 // --- Shared helpers for dashboard widgets ---
 function formatInt(n) {
   return (n || 0).toLocaleString();
@@ -1352,13 +1363,14 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     } catch (err) {
       console.error('Failed to fetch contractor profile', err);
-      const subheading = document.getElementById('dashboard-subheading');
-      if (subheading) {
-        subheading.textContent = 'Welcome back, Contractor';
-      }
+      showOfflineNotice();
     } finally {
       if (overlay) overlay.style.display = 'none';
     }
+  }, err => {
+    console.error('Auth state failed', err);
+    showOfflineNotice();
+    if (overlay) overlay.style.display = 'none';
   });
 });
 


### PR DESCRIPTION
## Summary
- serve cached pages first and add stale-while-revalidate caching for Firebase CDN scripts
- precache dashboard, tally, and auth-check pages while dropping farm-summary
- unhide dashboard immediately and show an offline notice if auth fails

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5656de3f08321a6669f0d3cb8479d