### PR TITLE
feat: improve offline support

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1251,6 +1251,11 @@ function initTop5FarmsWidget() {
 document.addEventListener('DOMContentLoaded', () => {
   const overlay = document.getElementById('loading-overlay');
   if (overlay) overlay.style.display = 'flex';
+  if (!(window.firebase && typeof firebase.auth === 'function')) {
+    showOfflineNotice();
+    if (overlay) overlay.style.display = 'none';
+    return;
+  }
 
   firebase.auth().onAuthStateChanged(async user => {
     if (!user) {

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,6 +1,6 @@
 // ✅ Bump the cache version whenever you change this file or add new assets
-const CACHE_NAME = 'sheariq-pwa-v9';
-const FIREBASE_CDN_CACHE = 'firebase-cdn-v1';
+const CACHE_NAME = 'sheariq-pwa-v10';
+const FIREBASE_CDN_CACHE = 'firebase-cdn';
 
 const FILES_TO_CACHE = [
   // HTML entry points (include the start_url from manifest)
@@ -12,9 +12,12 @@ const FILES_TO_CACHE = [
   // App assets (keep existing names; do NOT rename)
   'styles.css',
   'tally.js',
+  'dashboard.js',
   'auth.js',
   'export.js',
   'login.js',
+  'auth-check.js',
+  'firebase-init.js',
   'xlsx.full.min.js',
 
   // PWA essentials
@@ -48,9 +51,7 @@ self.addEventListener('fetch', event => {
   const url = new URL(event.request.url);
 
   // Runtime cache for Firebase CDN scripts
-  if (url.hostname === 'www.gstatic.com' &&
-      url.pathname.includes('/firebasejs/') &&
-      /(firebase-app-compat|firebase-auth-compat|firebase-firestore-compat)\.js$/.test(url.pathname)) {
+  if (url.href.startsWith('https://www.gstatic.com/firebasejs/')) {
     event.respondWith((async () => {
       const cache = await caches.open(FIREBASE_CDN_CACHE);
       const cached = await cache.match(event.request);
@@ -66,7 +67,6 @@ self.addEventListener('fetch', event => {
   // Skip other cross-origin and Firestore/WebChannel requests
   if (url.origin !== self.location.origin ||
       url.hostname.endsWith('googleapis.com') ||
-      url.hostname.endsWith('gstatic.com') ||
       url.pathname.includes('/google.firestore.v1.Firestore/Listen/channel')) {
     return; // Let the browser handle it
   }


### PR DESCRIPTION
## Summary
- cache Firebase CDN scripts and app assets in service worker for offline use
- fall back to cached page first and dashboard if missing
- show offline notice on dashboard when Firebase is unavailable

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5b5ea402083219e6e06ebdea03ad1