### PR TITLE
feat: render cached dashboard widgets on load

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1280,6 +1280,24 @@ button {
   width: 100%;
   max-width: none !important;
 }
+
+/* Skeleton placeholders for Top 5 widgets */
+.siq-lb-row.siq-lb-skeleton {
+  pointer-events: none;
+}
+.siq-lb-row.siq-lb-skeleton .siq-lb-rank,
+.siq-lb-row.siq-lb-skeleton .siq-lb-name,
+.siq-lb-row.siq-lb-skeleton .siq-lb-value {
+  background: #eee;
+  color: transparent;
+}
+.siq-lb-row.siq-lb-skeleton .siq-lb-bar {
+  background: #eee;
+}
+.siq-lb-row.siq-lb-skeleton .siq-lb-fill {
+  width: 100%;
+  background: #ddd;
+}
 /* --- Spacing between widgets + space below the row --- */
 #siq-widgets-grid{
   /* bigger gaps between the three cards */


### PR DESCRIPTION
## Summary
- render cached leaderboard rows before auth using `renderCachedTop5Widgets`
- avoid duplicate rendering by seeding `initTop5*` functions with cached data
- show fixed-height skeleton rows when no cache is available

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5bd82762c8321898eb7bb91dc2efc