### PR TITLE
feat: add skeleton placeholders for dashboard Top 5 widgets

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -319,21 +319,49 @@ function renderTop5Farms(rows, container) {
   }).join('');
 }
 
+// Render placeholder rows to reserve space until data arrives
+function renderSkeletonRows(container) {
+  if (!container) return;
+  container.innerHTML = Array.from({ length: 5 }).map(() => `
+    <div class="siq-lb-row skeleton">
+      <div class="siq-lb-rank">&nbsp;</div>
+      <div class="siq-lb-bar">
+        <div class="siq-lb-fill"></div>
+        <div class="siq-lb-name">&nbsp;</div>
+      </div>
+      <div class="siq-lb-value">&nbsp;</div>
+    </div>
+  `).join('');
+}
+
 function renderCachedTop5Widgets() {
   const shearersEl = document.querySelector('#top5-shearers #top5-shearers-list');
-  if (shearersEl && dashCache.top5Shearers && dashCache.top5Shearers.length) {
-    renderTop5Shearers(dashCache.top5Shearers, shearersEl);
-    dashCacheRendered.shearers = true;
+  if (shearersEl) {
+    if (dashCache.top5Shearers && dashCache.top5Shearers.length) {
+      renderTop5Shearers(dashCache.top5Shearers, shearersEl);
+      dashCacheRendered.shearers = true;
+    } else {
+      // No cache yet: show fixed-height skeleton rows to avoid layout jump
+      renderSkeletonRows(shearersEl);
+    }
   }
   const shedStaffEl = document.querySelector('#top5-shedstaff #top5-shedstaff-list');
-  if (shedStaffEl && dashCache.top5ShedStaff && dashCache.top5ShedStaff.length) {
-    renderTop5ShedStaff(dashCache.top5ShedStaff, shedStaffEl);
-    dashCacheRendered.shedstaff = true;
+  if (shedStaffEl) {
+    if (dashCache.top5ShedStaff && dashCache.top5ShedStaff.length) {
+      renderTop5ShedStaff(dashCache.top5ShedStaff, shedStaffEl);
+      dashCacheRendered.shedstaff = true;
+    } else {
+      renderSkeletonRows(shedStaffEl);
+    }
   }
   const farmsEl = document.querySelector('#top5-farms #top5-farms-list');
-  if (farmsEl && dashCache.top5Farms && dashCache.top5Farms.length) {
-    renderTop5Farms(dashCache.top5Farms, farmsEl);
-    dashCacheRendered.farms = true;
+  if (farmsEl) {
+    if (dashCache.top5Farms && dashCache.top5Farms.length) {
+      renderTop5Farms(dashCache.top5Farms, farmsEl);
+      dashCacheRendered.farms = true;
+    } else {
+      renderSkeletonRows(farmsEl);
+    }
   }
 }
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -1276,6 +1276,21 @@ button {
   line-height: 1.1;
 }
 
+/* Skeleton placeholders for Top 5 widgets */
+.siq-lb-row.skeleton .siq-lb-rank,
+.siq-lb-row.skeleton .siq-lb-name,
+.siq-lb-row.skeleton .siq-lb-value {
+  background: #1e2330;
+  color: transparent; /* reserve height without text */
+  border-radius: 4px;
+}
+.siq-lb-row.skeleton .siq-lb-name {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+.siq-lb-row.skeleton .siq-lb-fill { display: none; }
+
 #top5-shearers, #top5-shedstaff, #top5-farms {
   width: 100%;
   max-width: none !important;


### PR DESCRIPTION
## Summary
- show 5 fixed-height skeleton rows for each Top 5 widget when no cached data exists
- swap skeleton rows for live data once Firestore results arrive
- add lightweight styling for skeleton placeholders

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5cc6406688321934b647e5a37b8d5