### PR TITLE
Refresh KPI sheep count after session data loads

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -2144,7 +2144,11 @@ console.info('[SHEAR iQ] To backfill savedAt on older sessions, run: backfillSav
     URL.revokeObjectURL(url);
   });
 
-  // Initial draw (fill years + pill value)
+  // Initial setup
   fillYearsSelect();
-  refresh();
+  SessionStore.start(contractorId, { monthsLive: 12 });
+  SessionStore.onChange(() => {
+    window.__DASHBOARD_SESSIONS = SessionStore.getAll().map(d => ({ id: d.id, ...d.data() }));
+    refresh();
+  });
 })();


### PR DESCRIPTION
## Summary
- Refresh KPI sheep count when SessionStore data changes
- Track session data globally for reuse across dashboard

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a67e9633448321b8122bc13156425c