### PR TITLE
Refresh KPI sheep count when sessions already loaded

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -2146,9 +2146,17 @@ console.info('[SHEAR iQ] To backfill savedAt on older sessions, run: backfillSav
 
   // Initial setup
   fillYearsSelect();
-  SessionStore.start(contractorId, { monthsLive: 12 });
-  SessionStore.onChange(() => {
+
+  function updateFromStore() {
     window.__DASHBOARD_SESSIONS = SessionStore.getAll().map(d => ({ id: d.id, ...d.data() }));
     refresh();
-  });
+  }
+
+  SessionStore.onChange(updateFromStore);
+
+  if (SessionStore.getAll().length) {
+    updateFromStore();
+  }
+
+  SessionStore.start(contractorId, { monthsLive: 12 });
 })();


### PR DESCRIPTION
## Summary
- Refresh KPI sheep count immediately if sessions are already cached
- Register SessionStore listener before starting it so initial snapshot triggers refresh

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a68ce198e08321aa68f731d5b8897f