### PR TITLE
Add efficiency KPI

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -138,6 +138,10 @@
             <span class="kpi-label">Sheep Count</span>
             <span class="kpi-value" id="kpiSheepCountValue">—</span>
           </button>
+          <button class="kpi-pill" id="kpiEfficiency" aria-haspopup="dialog" aria-controls="kpiEfficiencyModal">
+            <span class="kpi-label">Efficiency</span>
+            <span class="kpi-value" id="kpiEfficiencyValue">—</span>
+          </button>
         </section>
 
         <!-- KPI MODAL (new) -->
@@ -187,6 +191,58 @@
             <footer class="kpi-actions">
               <button id="kpiExportCsv">Export CSV</button>
               <button id="kpiSheepCloseFooter">Close</button>
+            </footer>
+          </div>
+        </div>
+
+        <div id="kpiEfficiencyModal" class="kpi-modal" role="dialog" aria-modal="true" aria-labelledby="kpiEfficiencyTitle" hidden>
+          <div class="kpi-modal-card">
+            <header class="kpi-modal-header">
+              <h2 id="kpiEfficiencyTitle">Efficiency — Sheep per Hour</h2>
+              <button class="kpi-close" id="kpiEfficiencyClose" aria-label="Close">✕</button>
+            </header>
+
+            <div class="kpi-controls">
+              <label>
+                Year
+                <select id="kpiEffYearSelect"></select>
+              </label>
+              <label>
+                Farm
+                <select id="kpiEffFarmSelect">
+                  <option value="__ALL__">All farms</option>
+                </select>
+              </label>
+              <label>
+                <input type="checkbox" id="kpiEffIncludeCrutched"> Include crutched tallies
+              </label>
+              <small id="kpiEffOfflineNote" class="kpi-note" hidden>Offline data may be incomplete.</small>
+            </div>
+
+            <div class="kpi-sections">
+              <section>
+                <h3>Shearer Leaderboard</h3>
+                <table class="kpi-table" id="kpiEffShearerTable">
+                  <thead>
+                    <tr><th>Shearer</th><th>Sheep</th><th>Hours</th><th>Sheep/hr</th></tr>
+                  </thead>
+                  <tbody></tbody>
+                </table>
+              </section>
+
+              <section>
+                <h3>By Farm</h3>
+                <table class="kpi-table" id="kpiEffFarmTable">
+                  <thead>
+                    <tr><th>Farm</th><th>Sheep</th><th>Hours</th><th>Sheep/hr</th></tr>
+                  </thead>
+                  <tbody></tbody>
+                </table>
+              </section>
+            </div>
+
+            <footer class="kpi-actions">
+              <button id="kpiEfficiencyCloseFooter">Close</button>
             </footer>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add Efficiency KPI pill with modal for year, farm, and crutched filters
- compute sheep per hour averages by shearer and farm

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a694c32b008321a13e28d43a4af7e4