### PR TITLE
Add Total Hours KPI

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -142,6 +142,10 @@
             <span class="kpi-label">Efficiency</span>
             <span class="kpi-value" id="kpiEfficiencyValue">—</span>
           </button>
+          <button class="kpi-pill" id="kpiTotalHours" aria-haspopup="dialog" aria-controls="kpiTotalHoursModal">
+            <span class="kpi-label">Total Hours</span>
+            <span class="kpi-value" id="kpiTotalHoursValue">—</span>
+          </button>
         </section>
 
         <!-- KPI MODAL (new) -->
@@ -243,6 +247,82 @@
 
             <footer class="kpi-actions">
               <button id="kpiEfficiencyCloseFooter">Close</button>
+            </footer>
+          </div>
+        </div>
+
+        <div id="kpiTotalHoursModal" class="kpi-modal" role="dialog" aria-modal="true" aria-labelledby="kpiTotalHoursTitle" hidden>
+          <div class="kpi-modal-card">
+            <header class="kpi-modal-header">
+              <h2 id="kpiTotalHoursTitle">Total Hours — Session vs Crew</h2>
+              <button class="kpi-close" id="kpiTotalHoursClose" aria-label="Close">✕</button>
+            </header>
+
+            <div class="kpi-controls">
+              <label>
+                Year
+                <select id="kpiTHYearSelect"></select>
+              </label>
+              <label>
+                Farm
+                <select id="kpiTHFarmSelect">
+                  <option value="__ALL__">All farms</option>
+                </select>
+              </label>
+              <small id="kpiTHOfflineNote" class="kpi-note" hidden>Offline data may be incomplete.</small>
+            </div>
+
+            <div class="kpi-sections">
+              <section>
+                <h3>Summary</h3>
+                <table class="kpi-table">
+                  <thead>
+                    <tr><th>Metric</th><th>Total Hours</th></tr>
+                  </thead>
+                  <tbody id="kpiTHSummary">
+                    <!-- Filled by JS -->
+                  </tbody>
+                </table>
+                <small class="kpi-note">
+                  <strong>Session Hours</strong> = actual shed operating time per session.<br>
+                  <strong>Shed Staff / Shearers Hours</strong> = combined individual hours (higher; shows crew workload).
+                </small>
+              </section>
+
+              <section>
+                <h3>By Farm</h3>
+                <table class="kpi-table" id="kpiTHByFarm">
+                  <thead>
+                    <tr><th>Farm</th><th>Session Hours</th><th>Shed Staff Hours</th></tr>
+                  </thead>
+                  <tbody></tbody>
+                </table>
+              </section>
+
+              <section>
+                <h3>By Person</h3>
+                <table class="kpi-table" id="kpiTHByPerson">
+                  <thead>
+                    <tr><th>Name</th><th>Role</th><th>Days Worked</th><th>Total Hours</th><th>Avg Hours/Day</th></tr>
+                  </thead>
+                  <tbody></tbody>
+                </table>
+              </section>
+
+              <section>
+                <h3>By Month</h3>
+                <table class="kpi-table" id="kpiTHByMonth">
+                  <thead>
+                    <tr><th>Month</th><th>Session Hours</th></tr>
+                  </thead>
+                  <tbody></tbody>
+                </table>
+              </section>
+            </div>
+
+            <footer class="kpi-actions">
+              <button id="kpiTHExport">Export CSV</button>
+              <button id="kpiTotalHoursCloseFooter">Close</button>
             </footer>
           </div>
         </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1380,6 +1380,7 @@ button {
 .kpi-sections h3 { margin: 10px 0; }
 .kpi-table { width: 100%; border-collapse: collapse; }
 .kpi-table th, .kpi-table td { padding: 8px 10px; border-bottom: 1px solid var(--border-color, #2c2c2c); }
+.kpi-table td, .kpi-table th { white-space: nowrap; }
 .kpi-table th { text-align: left; opacity: .85; }
 .kpi-actions { display: flex; gap: 10px; justify-content: flex-end; padding: 12px 16px; border-top: 1px solid var(--border-color, #2c2c2c); }
 


### PR DESCRIPTION
## Summary
- Add Total Hours KPI pill above dashboard widgets
- Include modal showing session hours vs crew, with filters and tables
- Ensure KPI tables use no-wrap cells and support offline data note
- Use farm name helper and drop shearer-hours column from "By Farm" table

## Testing
- `npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_68a69a5911588321971509e05950902a