### PR TITLE
Use pickFarmName for Total Hours KPI farm names

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -2712,7 +2712,7 @@ console.info('[SHEAR iQ] To backfill savedAt on older sessions, run: backfillSav
     const farmsSet = new Set();
 
     sessions.forEach(s=>{
-      const farm = s.farmName || 'Unknown Farm';
+      const farm = pickFarmName(s) || 'Unknown Farm';
       if (farmFilter && farmFilter !== '__ALL__' && farm !== farmFilter) return;
 
       farmsSet.add(farm);
@@ -2791,7 +2791,7 @@ console.info('[SHEAR iQ] To backfill savedAt on older sessions, run: backfillSav
     offlineNote.hidden = !( !navigator.onLine );
 
     // Populate farms select
-    const farms = Array.from(new Set(sessions.map(s=>s.farmName || 'Unknown Farm'))).sort();
+    const farms = Array.from(new Set(sessions.map(s=>pickFarmName(s) || 'Unknown Farm'))).sort();
     const current = farmSel.value;
     farmSel.innerHTML = `<option value="__ALL__">All farms</option>` + farms.map(f=>`<option value="${f}">${f}</option>`).join('');
     if (farms.includes(current)) farmSel.value = current;


### PR DESCRIPTION
## Summary
- Use `pickFarmName` helper when aggregating Total Hours KPI and populating farm dropdown

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6a44789888321ba00ccd4803e349b