### PR TITLE
Remove shearer hours column from dashboard

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -285,7 +285,7 @@
                 </table>
                 <small class="kpi-note">
                   <strong>Session Hours</strong> = actual shed operating time per session.<br>
-                  <strong>Shed Staff / Shearers Hours</strong> = combined individual hours (higher; shows crew workload).
+                  <strong>Shed Staff Hours</strong> = combined individual hours (higher; shows crew workload).
                 </small>
               </section>
 
@@ -293,7 +293,7 @@
                 <h3>By Farm</h3>
                 <table class="kpi-table" id="kpiTHByFarm">
                   <thead>
-                    <tr><th>Farm</th><th>Session Hours</th><th>Shed Staff Hours</th><th>Shearers Hours</th></tr>
+                    <tr><th>Farm</th><th>Session Hours</th><th>Shed Staff Hours</th></tr>
                   </thead>
                   <tbody></tbody>
                 </table>


### PR DESCRIPTION
## Summary
- Drop Shearers Hours column and note from Total Hours dashboard table
- Stop rendering Shearers Hours in summary and farm breakdown
- Simplify aggregation to only session and shed staff hours

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6a44a0f508321ac8ae2f138ed95fb