### PR TITLE
Record per-shearer hours for efficiency metric

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -2251,6 +2251,11 @@ console.info('[SHEAR iQ] To backfill savedAt on older sessions, run: backfillSav
         arr.push({ name, hoursWorked: hrs });
       }
     }
+    else if (session?.hours && typeof session.hours === 'object') {
+      for (const [id, hrs] of Object.entries(session.hours)) {
+        arr.push({ name: id, hoursWorked: hrs });
+      }
+    }
     for (const entry of arr){
       if (!entry) continue;
       const name = normalizeName(entry.name || entry.shearerName || entry.displayName || entry.id || entry[0]);

--- a/public/tally.js
+++ b/public/tally.js
@@ -2480,7 +2480,18 @@ function collectExportData() {
             data.shedStaff.push({ name: name?.value || '', hours: hours?.value || '' });
         }
     });
- 
+
+    // Duplicate session hours for each shearer so efficiency calculations
+    // can treat hours on a per-shearer basis.
+    const sessionHours = data.hoursWorked;
+    const hoursMap = {};
+    if (sessionHours) {
+        data.stands.forEach(s => {
+            if (s.name) hoursMap[s.name] = sessionHours;
+        });
+    }
+    data.hours = hoursMap;
+
      document.querySelectorAll('#sheepTypeTotalsTable tbody tr').forEach(tr => {
          const cells = tr.querySelectorAll('td');
          if (cells.length >= 2) {


### PR DESCRIPTION
## Summary
- Duplicate session "Hours Worked" for every shearer when saving a tally
- Update efficiency aggregation to read per-shearer hour maps

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6a74ba5008321a73a8cabb30b4967