### PR TITLE
refactor: centralize year dropdown helper

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -172,6 +172,17 @@ function sumSheep(session) {
   return total;
 }
 
+// Populate a <select> with year options from the current year backwards.
+// Defaults to 6 years and sets the select's value to the current year.
+function fillYearsSelect(sel, yearsBack = 6) {
+  if (!sel) return;
+  const thisYear = new Date().getFullYear();
+  const years = [];
+  for (let y = thisYear; y >= thisYear - yearsBack; y--) years.push(y);
+  sel.innerHTML = years.map(y => `<option value="${y}">${y}</option>`).join('');
+  sel.value = String(thisYear);
+}
+
 // Persist last dashboard widget data to avoid first-paint flash
 const dashCache = (() => {
   try { return JSON.parse(localStorage.getItem('dashboard_cache_v1') || '{}'); }
@@ -2919,13 +2930,6 @@ console.info('[SHEAR iQ] To backfill savedAt on older sessions, run: backfillSav
   farmSel?.addEventListener('change', refresh);
 
   // Init: fill years
-  function fillYearsSelect(sel){
-    const thisYear = new Date().getFullYear();
-    const years = [];
-    for (let y = thisYear; y >= thisYear - 6; y--) years.push(y);
-    sel.innerHTML = years.map(y => `<option value="${y}">${y}</option>`).join('');
-    sel.value = String(thisYear);
-  }
   fillYearsSelect(yearSel);
 
   SessionStore.onChange(refresh);
@@ -3097,12 +3101,6 @@ console.info('[SHEAR iQ] To backfill savedAt on older sessions, run: backfillSav
   });
 
   // Init: fill years
-  function fillYearsSelect(sel){
-    const thisYear=new Date().getFullYear();
-    const years=[]; for(let y=thisYear;y>=thisYear-6;y--) years.push(y);
-    sel.innerHTML=years.map(y=>`<option value="${y}">${y}</option>`).join('');
-    sel.value=String(thisYear);
-  }
   fillYearsSelect(yearSel);
 
   SessionStore.onChange(refresh);


### PR DESCRIPTION
## Summary
- add reusable `fillYearsSelect` utility
- use shared helper in total hours and days worked KPIs

## Testing
- `node <<'NODE'
const stubEl = () => ({
  innerHTML:'', value:'', textContent:'', style:{}, className:'', children:[],
  addEventListener(){}, removeEventListener(){}, appendChild(){}, setAttribute(){}, querySelector(){return null;},
});
const document = {
  elements: {
    kpiTHYearSelect: stubEl(),
    kpiDWYearSelect: stubEl(),
  },
  getElementById(id){ return this.elements[id] || null; },
  querySelector(sel){ return null; },
  createElement(tag){ return stubEl(); },
  addEventListener(){},
  removeEventListener(){},
  body: stubEl(),
};
const window = { document, addEventListener(){}, removeEventListener(){}, navigator:{ onLine: true }, location:{ href:'', assign(){}, replace(){} } };

global.window = window;
global.document = document;
global.navigator = window.navigator;
const store={};
function makeStorage(){
  return {getItem:k=> (k in store? store[k]:null), setItem:(k,v)=>{store[k]=String(v);}, removeItem:k=>{delete store[k];}, clear:()=>{for(const k in store) delete store[k];}};
}
global.localStorage = makeStorage();
global.sessionStorage = makeStorage();
global.confirm = () => true;
// firebase stub
global.firebase = { auth: () => ({ onAuthStateChanged: () => {}, signOut: () => Promise.resolve() }) };
import('./public/dashboard.js').then(() => {
  const thSel = document.getElementById('kpiTHYearSelect');
  const dwSel = document.getElementById('kpiDWYearSelect');
  console.log('TH options:', thSel.innerHTML);
  console.log('DW options:', dwSel.innerHTML);
}).catch(err => console.error('Error', err));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a6c5b24e44832186fa07336b4ce729