### PR TITLE
Consider session hours map for max hours

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -2501,6 +2501,11 @@ console.info('[SHEAR iQ] To backfill savedAt on older sessions, run: backfillSav
         maxH = Math.max(maxH, parseHours(ss.hoursWorked || ss.totalHours || ss.hours));
       });
     }
+    if (session && typeof session.hours === 'object' && session.hours) {
+      Object.values(session.hours).forEach(h => {
+        maxH = Math.max(maxH, parseHours(h));
+      });
+    }
     return maxH || 0;
   }
 
@@ -2513,6 +2518,14 @@ console.info('[SHEAR iQ] To backfill savedAt on older sessions, run: backfillSav
       session.shearers.forEach(sh => {
         const hours = parseHours(sh.hoursWorked || sh.totalHours || sh.hours);
         if (hours > 0) push({ name: sh.name || sh.shearerName || 'Unknown', role: 'Shearer', dateKey: dayStr, hours });
+      });
+    } else {
+      const names = Array.isArray(session?.stands)
+        ? session.stands
+        : Object.keys(session?.hours || {});
+      names.forEach(name => {
+        const hours = parseHours(session?.hours?.[name]);
+        if (hours > 0) push({ name, role: 'Shearer', dateKey: dayStr, hours });
       });
     }
     if (Array.isArray(session?.shedStaff)) {


### PR DESCRIPTION
## Summary
- derive session runtime from stand-hour map when individual records are absent
- synthesize shearer entries from stand list or hour map when `session.shearers` is missing

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a6c99caeb48321973db575c35c6d89