### PR TITLE
Fix Top 5 widgets not rendering after navigation

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -743,6 +743,8 @@ function initTop5ShearersWidget() {
         renderFromCache();
       });
     }
+    // Ensure widget renders even when no SessionStore change fires
+    scheduleRender();
 
     tabs.addEventListener('click', e => {
       if (!rootEl) return;
@@ -1359,8 +1361,10 @@ function initTop5FarmsWidget() {
       renderPending = true;
       requestAnimationFrame(() => { renderPending = false; renderFromCache(); });
     }
+    // Kick off an initial render so cached sessions populate the view
+    scheduleRender();
 
-      viewSel.addEventListener('change', () => {
+    viewSel.addEventListener('change', () => {
         const v = viewSel.value;
         if (v === 'all') {
           yearSel.hidden = true;


### PR DESCRIPTION
## Summary
- Ensure Top 5 Shearers and Farms widgets trigger an initial render using cached session data so View All lists populate after returning to the dashboard.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a6fc54c4c48321baa3001808ccb79b