### PR TITLE
feat: add per-shearer sheep/hour breakdown

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -218,12 +218,18 @@
                   <option value="__ALL__">All farms</option>
                 </select>
               </label>
-              <button id="kpiSPHClearFarm" class="kpi-clear">Clear Filter</button>
+              <label>
+                Sheep Type
+                <select id="kpiSPHTypeSelect">
+                  <option value="__ALL__">All types</option>
+                </select>
+              </label>
+              <button id="kpiSPHClearFilters" class="kpi-clear">Clear Filters</button>
             </div>
 
             <table class="kpi-table" id="kpiSPHTable">
               <thead>
-                <tr><th>Sheep Type</th><th>Total</th></tr>
+                <tr><th>Shearer</th><th>Total Sheep</th><th>Total Hours</th><th>Sheep/Hour</th></tr>
               </thead>
               <tbody></tbody>
             </table>


### PR DESCRIPTION
## Summary
- expand Sheep Per Hour KPI modal to list each shearer's total sheep, hours worked, and rate
- add farm and sheep type filters for the breakdown table
- render sortable table with per-shearer averages

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a7008a2c8c8321b15b7d3b4e161e3f