### PR TITLE
Add password reset page and link

### DIFF
--- a/public/forgot-password.html
+++ b/public/forgot-password.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Reset Password - SHEAR iQ</title>
+  <link rel="stylesheet" href="styles.css" />
+  <style>
+    body {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+      margin: 0;
+      background: #000;
+      color: #fff;
+    }
+    #forgotPasswordForm {
+      background: #000;
+      padding: 20px;
+      border-radius: 4px;
+      width: 300px;
+    }
+    #forgotPasswordForm input {
+      width: 100%;
+      padding: 8px;
+      margin: 6px 0;
+    }
+    #forgotPasswordForm button {
+      width: 100%;
+      padding: 10px;
+    }
+    #message {
+      margin-top: 10px;
+      text-align: center;
+      min-height: 1.2em;
+    }
+  </style>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
+  <script src="firebase-init.js"></script>
+  <script src="forgot-password.js"></script>
+</head>
+<body>
+  <form id="forgotPasswordForm">
+    <h2>Reset Password</h2>
+    <input type="email" id="email" placeholder="Email" required />
+    <button type="submit">Send Reset Email</button>
+    <div id="message"></div>
+  </form>
+</body>
+</html>
+

--- a/public/forgot-password.js
+++ b/public/forgot-password.js
@@ -1,0 +1,29 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const auth = firebase.auth();
+  const form = document.getElementById('forgotPasswordForm');
+  const messageDiv = document.getElementById('message');
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const email = document.getElementById('email').value.trim();
+
+    try {
+      await auth.sendPasswordResetEmail(email);
+      messageDiv.innerHTML = 'Password reset email sent. <a href="login.html">Return to login</a>';
+    } catch (err) {
+      let msg = '';
+      switch (err.code) {
+        case 'auth/invalid-email':
+          msg = 'Please enter a valid email address';
+          break;
+        case 'auth/user-not-found':
+          msg = 'No user found with that email';
+          break;
+        default:
+          msg = 'Failed to send reset email. Please try again';
+      }
+      messageDiv.textContent = msg;
+    }
+  });
+});
+

--- a/public/login.html
+++ b/public/login.html
@@ -53,13 +53,14 @@
       <input type="password" id="password" placeholder="Password" required>
       <button type="button" class="toggle-password" data-target="password">Show</button>
     </div>
-    <label id="rememberMeLabel">
-      <input type="checkbox" id="rememberMe">
-      Remember Me
-    </label>
-    <button type="submit">Login</button>
-    <div id="login-error"></div>
-  </form>
+      <label id="rememberMeLabel">
+        <input type="checkbox" id="rememberMe">
+        Remember Me
+      </label>
+      <a id="forgotPassword" href="forgot-password.html">Forgot password?</a>
+      <button type="submit">Login</button>
+      <div id="login-error"></div>
+    </form>
   <div id="loading-overlay">
     <div class="circle-spinner"></div>
     <div>Starting your shed session…</div>


### PR DESCRIPTION
## Summary
- add "Forgot password?" link on login page
- create reset page and Firebase-driven reset logic
- send password reset email and show link back to login

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a70ae2a2648321859c31216a7de338