### PR TITLE
feat: add custom password reset email

### DIFF
--- a/public/forgot-password.html
+++ b/public/forgot-password.html
@@ -38,6 +38,7 @@
   </style>
   <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-functions-compat.js"></script>
   <script src="firebase-init.js"></script>
   <script src="forgot-password.js"></script>
 </head>

--- a/public/forgot-password.js
+++ b/public/forgot-password.js
@@ -1,5 +1,5 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const auth = firebase.auth();
+  const functions = firebase.functions();
   const form = document.getElementById('forgotPasswordForm');
   const messageDiv = document.getElementById('message');
 
@@ -8,15 +8,16 @@ document.addEventListener('DOMContentLoaded', () => {
     const email = document.getElementById('email').value.trim();
 
     try {
-      await auth.sendPasswordResetEmail(email);
+      const sendReset = functions.httpsCallable('sendPasswordResetEmail');
+      await sendReset({ email });
       messageDiv.innerHTML = 'Password reset email sent. <a href="login.html">Return to login</a>';
     } catch (err) {
       let msg = '';
       switch (err.code) {
-        case 'auth/invalid-email':
+        case 'functions/invalid-argument':
           msg = 'Please enter a valid email address';
           break;
-        case 'auth/user-not-found':
+        case 'functions/not-found':
           msg = 'No user found with that email';
           break;
         default:


### PR DESCRIPTION
## Summary
- send password reset emails with SHEΔR iQ tone via Cloud Function
- call new function from forgot password page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm --prefix functions test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a712d05ec883219159bada572056ed