### PR TITLE
Align forgot password link with remember me

### DIFF
--- a/public/login.html
+++ b/public/login.html
@@ -18,10 +18,15 @@
     #loginForm { background: #000; padding: 20px; border-radius: 4px; width: 300px; }
     #loginForm input:not([type="checkbox"]) { width: 100%; padding: 8px; margin: 6px 0; }
     #loginForm button[type="submit"] { width: 100%; padding: 10px; }
+    #rememberForgotContainer {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin: 6px 0;
+    }
     #rememberMeLabel {
       display: flex;
       align-items: center;
-      margin: 6px 0;
     }
     #rememberMeLabel input { width: auto; margin-right: 6px; }
     #login-error {
@@ -38,9 +43,7 @@
       height: auto;
     }
     #forgotPassword {
-      display: block;
-      margin: 6px 0;
-      text-align: right;
+      margin: 0;
       color: #ffea00;
       text-decoration: none;
     }
@@ -63,11 +66,13 @@
       <input type="password" id="password" placeholder="Password" required>
       <button type="button" class="toggle-password" data-target="password">Show</button>
     </div>
-      <label id="rememberMeLabel">
-        <input type="checkbox" id="rememberMe">
-        Remember Me
-      </label>
-      <a id="forgotPassword" href="forgot-password.html">Forgot Password?</a>
+      <div id="rememberForgotContainer">
+        <label id="rememberMeLabel">
+          <input type="checkbox" id="rememberMe">
+          Remember Me
+        </label>
+        <a id="forgotPassword" href="forgot-password.html">Forgot Password?</a>
+      </div>
       <button type="submit">Login</button>
       <div id="login-error"></div>
     </form>


### PR DESCRIPTION
## Summary
- Align "Forgot Password?" link with the "Remember Me" checkbox using a flex container.
- Streamline styles for the login form's remember/forgot section.

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a714e85bc8832181c2fc8d880b1a23