### PR TITLE
Handle empty leaderboard states

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -366,6 +366,15 @@ function renderSkeletonRows(container) {
   `).join('');
 }
 
+function renderEmptyLeaderboard(container, modalTbody, message) {
+  if (container) {
+    container.innerHTML = `<div class="siq-lb-empty">${message}</div>`;
+  }
+  if (modalTbody) {
+    modalTbody.innerHTML = `<tr><td colspan="3" class="siq-lb-empty">${message}</td></tr>`;
+  }
+}
+
 function renderCachedTop5Widgets() {
   const shearersEl = document.querySelector('#top5-shearers #top5-shearers-list');
   if (shearersEl) {
@@ -726,8 +735,7 @@ function initTop5ShearersWidget() {
       function renderFromCache() {
         if (!cachedSessions.length) {
           if (!(dashCache.top5Shearers && dashCache.top5Shearers.length)) {
-            listEl.innerHTML = '';
-            modalBodyTbody.innerHTML = '';
+            renderEmptyLeaderboard(listEl, modalBodyTbody, 'No sessions yet');
           }
           return;
         }
@@ -1077,8 +1085,7 @@ function initTop5ShedStaffWidget() {
     function renderFromCache() {
       if (!cachedSessions.length) {
         if (!(dashCache.top5ShedStaff && dashCache.top5ShedStaff.length)) {
-          listEl.innerHTML = '';
-          modalBodyTbody.innerHTML = '';
+          renderEmptyLeaderboard(listEl, modalBodyTbody, 'No sessions yet');
         }
         cachedSig = '';
         return;
@@ -1342,8 +1349,7 @@ function initTop5FarmsWidget() {
     function renderFromCache() {
       if (!cachedSessions.length) {
         if (!(dashCache.top5Farms && dashCache.top5Farms.length)) {
-          listEl.innerHTML = '';
-          modalBodyTbody.innerHTML = '';
+          renderEmptyLeaderboard(listEl, modalBodyTbody, 'No sessions yet');
         }
         return;
       }

--- a/public/styles.css
+++ b/public/styles.css
@@ -596,6 +596,12 @@ button {
   align-items: center;
   gap: 10px;
 }
+#top5-shearers .siq-lb-empty , #top5-shedstaff .siq-lb-empty , #top5-farms .siq-lb-empty {
+  color: #b9c2d0;
+  text-align: center;
+  font-size: 0.9rem;
+  padding: 8px 0;
+}
 #top5-shearers .siq-lb-rank , #top5-shedstaff .siq-lb-rank , #top5-farms .siq-lb-rank {
   color: #8c94a7;
   text-align: right;


### PR DESCRIPTION
## Summary
- add renderEmptyLeaderboard helper to show placeholder text when leaderboards have no sessions
- use helper in shearer, shed staff, and farm cache renders
- style empty leaderboard messaging

## Testing
- `node - <<'NODE' ... NODE`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a71fe1972483219840ff0c6c947785