### PR TITLE
style: emphasize setup day modal labels

### DIFF
--- a/public/tally.html
+++ b/public/tally.html
@@ -123,8 +123,11 @@
   .field-hint{
     display:block;
     margin:4px 0 8px;
-    font-size:0.9rem;
-    opacity:0.8;
+    font-size:0.85rem;
+    color:#555;
+  }
+  #setupModal .form-row > label{
+    font-weight:600;
   }
 </style>
 <!-- Ultra-early launch redirect + no-flash guard -->


### PR DESCRIPTION
## Summary
- make Setup Day modal labels stand out with bold styling
- tone down informational hint text

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a725e1b39883219e5c469b4cbf0539