### PR TITLE
fix: backfill savedAt for old sessions

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1520,6 +1520,11 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         SessionStore.start(user.uid, { monthsLive: 12 });
+        if (!localStorage.getItem('savedAtBackfilled') && typeof backfillSavedAtForSessions === 'function') {
+          backfillSavedAtForSessions().finally(() => {
+            try { localStorage.setItem('savedAtBackfilled', 'true'); } catch {}
+          });
+        }
         document.addEventListener('visibilitychange', () => {
           if (document.hidden) {
             SessionStore.stop();


### PR DESCRIPTION
## Summary
- ensure session documents missing `savedAt` get backfilled on dashboard start so older sessions appear

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a724ad349c83219670941011fddba0