### PR TITLE
Improve Setup Day help text visibility

### DIFF
--- a/public/tally.html
+++ b/public/tally.html
@@ -124,7 +124,7 @@
     display:block;
     margin:4px 0 8px;
     font-size:0.85rem;
-    color:#555;
+    color:#222;
   }
   #setupModal .form-row > label{
     font-weight:600;


### PR DESCRIPTION
## Summary
- Darken Setup Day modal help text for better readability

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a72da50e108321be1bfdb7cc68c6ec