### PR TITLE
Control tally cleanup via finish time

### DIFF
--- a/public/tally.html
+++ b/public/tally.html
@@ -578,6 +578,7 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   function performReset(full) {
+  if (!full) allowCleanup = false;
   clearCommonFields();
   // Always clear cached session metadata so a new day doesn't reuse the old ID
   if (window.resetForNewDay) window.resetForNewDay();

--- a/public/tally.js
+++ b/public/tally.js
@@ -350,6 +350,7 @@ let hasUserStartedEnteringData = false;
 let hasTouchedTallyInputs = false;
 // Ensure the Finish Time warning is only shown once
 let hasShownFinishTimeWarning = false;
+let allowCleanup = false;
 
 // === Autosave state ===
 let autosaveTimer = null;
@@ -1609,6 +1610,9 @@ function initAutoHoursField(input) {
     updateLunchToggleButton();
    if (start) start.addEventListener('change', handleStartTimeChange);
    if (end) {
+     end.addEventListener('input', e => {
+       allowCleanup = !!e.target.value.trim();
+     });
      end.addEventListener('change', () => {
        if (!hasTouchedTallyInputs && !hasShownFinishTimeWarning) {
          const enteredTime = end.value;
@@ -1757,11 +1761,8 @@ let saveCallback = null;
 let manualSave = false;
 
 function performSave(saveLocal, saveCloud, manual) {
-    const finishTime = document.getElementById('finishTime')?.value;
-    const sessionHasEnded = finishTime && finishTime.trim() !== '';
-
     if ((isSetupComplete && hasUserStartedEnteringData) || manual) {
-        if (sessionHasEnded || manual) {
+        if (allowCleanup || manual) {
             cleanUpEmptyRowsAndColumns(manual);
         }
     }


### PR DESCRIPTION
## Summary
- add `allowCleanup` flag and toggle based on Finish Time input
- reset cleanup allowance on partial reset
- run cleanup only when allowed or for manual saves

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a745c2543083218c434ab1111bd777