### PR TITLE
fix: respect session date for dashboard year filter

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -234,21 +234,28 @@ const SessionStore = (() => {
     const data = typeof first.data === 'function' ? first.data() : first.data;
     let year = null;
     try {
-      if (data?.savedAt && typeof data.savedAt.toDate === 'function') {
+      // Prefer explicit session date if available
+      if (data?.date) {
+        if (typeof data.date === 'string') {
+          const ds = data.date.trim();
+          let m = ds.match(/^\d{4}-\d{2}-\d{2}$/);
+          if (m) {
+            year = parseInt(ds.slice(0, 4), 10);
+          } else {
+            m = ds.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+            if (m) year = parseInt(m[3], 10);
+          }
+        } else if (typeof data.date.toDate === 'function') {
+          const d = data.date.toDate();
+          if (d && !isNaN(d.getTime())) year = d.getFullYear();
+        }
+      }
+      // Fallback to savedAt timestamp
+      if (!year && data?.savedAt && typeof data.savedAt.toDate === 'function') {
         const d = data.savedAt.toDate();
         if (d && !isNaN(d.getTime())) year = d.getFullYear();
       }
     } catch {}
-    if (!year && typeof data?.date === 'string') {
-      const ds = data.date.trim();
-      let m = ds.match(/^\d{4}-\d{2}-\d{2}$/);
-      if (m) {
-        year = parseInt(ds.slice(0, 4), 10);
-      } else {
-        m = ds.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
-        if (m) year = parseInt(m[3], 10);
-      }
-    }
     if (!year) return;
 
     // Initialize each select that doesn't yet have a year selected.


### PR DESCRIPTION
## Summary
- prefer session.date over savedAt when initializing Top 5 widget year filters
- fall back to savedAt if a session's date is missing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7454baa94832183a40f834485faf5