### PR TITLE
Ensure active session resumes unlocked

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1551,6 +1551,7 @@ document.addEventListener('DOMContentLoaded', () => {
         btnReturnToActive.style.display = 'block';
         btnReturnToActive.addEventListener('click', () => {
           sessionStorage.setItem('launch_override', 'tally');
+          try { localStorage.setItem('viewOnlyMode', 'false'); } catch (e) {}
           window.location.href = 'tally.html?loadedSession=true';
         });
       }

--- a/public/tally.js
+++ b/public/tally.js
@@ -2918,11 +2918,17 @@ function loadSessionObject(session) {
     lastLocalSave = now;
     lastCloudSave = now;
     
-    // Always enforce locking first so any subsequent DOM manipulation
-    // doesn't accidentally trigger focus events while unlocked
-    enforceSessionLock(session.date);
-    if (session.viewOnly) {
-       lockSession(); // Let focusin listener handle PIN prompt if needed
+    const viewOnlyFlag = localStorage.getItem('viewOnlyMode');
+
+    if (typeof isLoadedSession !== 'undefined' && isLoadedSession && viewOnlyFlag === null) {
+        unlockSession();
+    } else {
+        // Always enforce locking first so any subsequent DOM manipulation
+        // doesn't accidentally trigger focus events while unlocked
+        enforceSessionLock(session.date);
+        if (session.viewOnly) {
+           lockSession(); // Let focusin listener handle PIN prompt if needed
+        }
     }
     populateSessionData(session);
     rebuildRowsFromSession(session);


### PR DESCRIPTION
## Summary
- Clear view-only flag before navigating back to an active session from the dashboard
- Default loaded sessions without a view-only flag to unlocked in tally view

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a74bac8c348321b84292dfa80a27da