### PR TITLE
Cancel autosave before data entry and remove active session on reset

### DIFF
--- a/public/tally.html
+++ b/public/tally.html
@@ -596,6 +596,11 @@ document.addEventListener('DOMContentLoaded', function () {
 
   const table = document.getElementById('tallyTable');
   if (table) table.dispatchEvent(new Event('input', { bubbles: true }));
+  if (typeof autosaveTimer !== 'undefined') {
+    clearTimeout(autosaveTimer);
+    autosaveTimer = null;
+  }
+  localStorage.removeItem('active_session');
   hideModal();
   if (window.unlockSession) window.unlockSession();
 }

--- a/public/tally.js
+++ b/public/tally.js
@@ -485,6 +485,13 @@ function showAutosaveStatus(message, mode) {
 }
 
 function scheduleAutosave() {
+    if (!hasUserStartedEnteringData) {
+        if (autosaveTimer) {
+            clearTimeout(autosaveTimer);
+            autosaveTimer = null;
+        }
+        return;
+    }
     if (autosaveTimer) clearTimeout(autosaveTimer);
     autosaveTimer = setTimeout(() => {
         const mode = localStorage.getItem('tally_autosave_mode') || 'both';


### PR DESCRIPTION
## Summary
- Skip scheduling autosave until the user begins entering data
- Clear any pending autosave timer and remove `active_session` from localStorage during reset

## Testing
- `node - <<'NODE'` (simulate reset and dashboard behavior)
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a74ec68aa88321a8a72a318da7b426