### PR TITLE
feat: add setup reminder toast

### DIFF
--- a/public/tally.html
+++ b/public/tally.html
@@ -732,6 +732,20 @@ document.addEventListener('DOMContentLoaded', function () {
       z-index: 9999;
       display: none;
     }
+    #setup-reminder-toast {
+      position: fixed;
+      bottom: 20px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: rgba(20,20,20,0.95);
+      color: #fff;
+      padding: 8px 12px;
+      border-radius: 6px;
+      font-size: 14px;
+      z-index: 9999;
+      display: none;
+      cursor: pointer;
+    }
   </style>
 
 <style id="tt-help-menu-base">

--- a/public/tally.js
+++ b/public/tally.js
@@ -924,6 +924,8 @@ function showSetupModal() {
     const modal = document.getElementById('setupModal');
     if (!modal) return;
     modal.style.display = 'flex';
+    const reminder = document.getElementById('setup-reminder-toast');
+    if (reminder) reminder.style.display = 'none';
 
     const disableChk = document.getElementById('disableSetupModalFromSetup');
     if (disableChk){
@@ -940,6 +942,24 @@ function showSetupModal() {
 function hideSetupModal() {
     const modal = document.getElementById('setupModal');
     if (modal) modal.style.display = 'none';
+    if (isSetupModalEnabled()) showSetupReminderToast();
+}
+
+function showSetupReminderToast() {
+    let toast = document.getElementById('setup-reminder-toast');
+    if (!toast) {
+        toast = document.createElement('div');
+        toast.id = 'setup-reminder-toast';
+        toast.textContent = 'Setup dismissed. Tap to reopen.';
+        document.body.appendChild(toast);
+        toast.addEventListener('click', () => {
+            toast.style.display = 'none';
+            showSetupModal();
+        });
+    }
+    toast.style.display = 'block';
+    clearTimeout(showSetupReminderToast._t);
+    showSetupReminderToast._t = setTimeout(() => { toast.style.display = 'none'; }, 3000);
 }
 
 function confirmSetupModal() {


### PR DESCRIPTION
## Summary
- add a toast reminder that appears when the Setup Day modal closes
- allow clicking toast to reopen the Setup Day modal
- include styles for new toast element

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a74f8f48288321ab1324511e932c79