### PR TITLE
Fix width of deleted staff table

### DIFF
--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -320,9 +320,10 @@
       padding: 4px 8px;
     }
 
-    /* Make the label column narrow so the email column gets space */
-    .table-scroll .staff-table th:first-child,
-    .table-scroll .staff-table td:first-child {
+    /* Make the first column narrow only for the active staff table so
+       the email column gets more space without affecting deleted staff */
+    #staffTable th:first-child,
+    #staffTable td:first-child {
       width: 1%;
     }
 


### PR DESCRIPTION
## Summary
- Prevent first column width rule from narrowing deleted staff table
- Apply narrow first column only to active staff table

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a75e98574883219408056f1fa46531