### PR TITLE
Number people in Days Worked table

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -361,7 +361,7 @@
             <section>
               <h3>By Person</h3>
               <table class="kpi-table" id="kpiDWByPerson">
-                <thead><tr><th>Name</th><th>Role</th><th>Days Worked</th></tr></thead>
+                <thead><tr><th>#</th><th>Name</th><th>Role</th><th>Days Worked</th></tr></thead>
                 <tbody></tbody>
               </table>
             </section>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -3141,7 +3141,7 @@ console.info('[SHEAR iQ] To backfill savedAt on older sessions, run: backfillSav
   }
   function renderSummary(val){ tbodySummary.innerHTML = `<tr><td>Days Worked</td><td>${val}</td></tr>`; }
   function renderByFarm(rows){ tblByFarm.innerHTML = rows.map(r=>`<tr><td>${r.farm}</td><td>${r.days}</td></tr>`).join(''); }
-  function renderByPerson(rows){ tblByPerson.innerHTML = rows.map(r=>`<tr><td>${r.name}</td><td>${r.role}</td><td>${r.days}</td></tr>`).join(''); }
+  function renderByPerson(rows){ tblByPerson.innerHTML = rows.map((r,i)=>`<tr><td>${i+1}</td><td>${r.name}</td><td>${r.role}</td><td>${r.days}</td></tr>`).join(''); }
   function renderByMonth(rows){ tblByMonth.innerHTML = rows.map(r=>`<tr><td>${r.month}</td><td>${r.days}</td></tr>`).join(''); }
 
   async function refresh(){


### PR DESCRIPTION
## Summary
- Show a numbered column in the Days Worked KPI's by-person table
- Render row numbers via JavaScript when filling the table

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a75f48c7e883219a6a1bb1d04caf5f