### PR TITLE
style: simplify sheep per hour pill

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -141,7 +141,6 @@
           <button class="kpi-pill" id="kpiSheepPerHour" aria-haspopup="dialog" aria-controls="kpiSheepPerHourModal">
             <span class="kpi-label">Sheep Per Hour</span>
             <span class="kpi-value" id="kpiSheepPerHourValue">—</span>
-            <span class="kpi-meta" id="kpiSheepPerHourMeta"></span>
           </button>
           <button class="kpi-pill" id="kpiTotalHours" aria-haspopup="dialog" aria-controls="kpiTotalHoursModal">
             <span class="kpi-label">Total Hours</span>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -2350,7 +2350,6 @@ console.info('[SHEAR iQ] To backfill savedAt on older sessions, run: backfillSav
 (function setupKpiSheepPerHour(){
   const pill = document.getElementById('kpiSheepPerHour');
   const pillVal = document.getElementById('kpiSheepPerHourValue');
-  const pillMeta = document.getElementById('kpiSheepPerHourMeta');
   const modal = document.getElementById('kpiSheepPerHourModal');
   const closeX = document.getElementById('kpiSheepPerHourClose');
   const closeFooter = document.getElementById('kpiSheepPerHourCloseFooter');
@@ -2364,9 +2363,6 @@ console.info('[SHEAR iQ] To backfill savedAt on older sessions, run: backfillSav
 
   if (dashCache.kpiSheepPerHourRate != null) {
     pillVal.textContent = dashCache.kpiSheepPerHourRate;
-    if (pillMeta && dashCache.kpiSheepPerHourMeta) {
-      pillMeta.textContent = dashCache.kpiSheepPerHourMeta;
-    }
   }
 
   const contractorId = localStorage.getItem('contractor_id') || (window.firebase?.auth()?.currentUser?.uid) || null;
@@ -2689,13 +2685,8 @@ console.info('[SHEAR iQ] To backfill savedAt on older sessions, run: backfillSav
   function updatePill(stats){
     const rate = stats.totalHours > 0 ? (stats.totalSheep / stats.totalHours) : 0;
     const rateText = rate > 0 ? rate.toFixed(1) : '—';
-    const displayTotalHM = window.aggDisplayHours || hoursToHM((window.aggTotalMins || 0) / 60);
-    const metaHoursText = /[a-z]/i.test(displayTotalHM) ? displayTotalHM : `${displayTotalHM} hours`;
-    const metaText = `${stats.days} days • ${metaHoursText}`;
     pillVal.textContent = rateText;
-    if (pillMeta) pillMeta.textContent = metaText;
     dashCache.kpiSheepPerHourRate = rateText;
-    dashCache.kpiSheepPerHourMeta = metaText;
     saveDashCache();
   }
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -1364,8 +1364,8 @@ button {
 .kpi-value {
   font-weight: 700;
   font-variant-numeric: tabular-nums;
-  font-size: 1.25rem;
-  color: var(--kpi-value-color, #ffd700);
+  font-size: 0.8rem;
+  color: #39ff14;
 }
 .kpi-meta { font-size: .75rem; opacity: .7; }
 


### PR DESCRIPTION
## Summary
- make KPI pill numbers small and bright green
- drop days/hours metadata from sheep per hour pill

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a764cab51883218dfb75f3e00c6883