### PR TITLE
Add total crew hours row in hours worked KPI summary

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -282,7 +282,8 @@
                 </table>
                 <small class="kpi-note">
                   <strong>Session Hours</strong> = actual shed operating time per session.<br>
-                  <strong>Shed Staff Hours</strong> = combined individual hours (higher; shows crew workload).
+                  <strong>Total Crew Hours</strong> = combined individual hours for all people in a session.<br>
+                  <strong>Shed Staff Hours</strong> = combined individual hours for shed staff only.
                 </small>
               </section>
 

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -2899,9 +2899,10 @@ console.info('[SHEAR iQ] To backfill savedAt on older sessions, run: backfillSav
     saveDashCache();
   }
 
-  function renderSummary(sessionHours, shedStaffHours){
+  function renderSummary(sessionHours, crewHours, shedStaffHours){
     tbodySummary.innerHTML = `
       <tr><td>Session Hours (pill metric)</td><td>${hoursToHM(sessionHours)}</td></tr>
+      <tr><td>Total Crew Hours</td><td>${hoursToHM(crewHours)}</td></tr>
       <tr><td>Shed Staff Hours (combined)</td><td>${hoursToHM(shedStaffHours)}</td></tr>
     `;
   }
@@ -2951,6 +2952,7 @@ console.info('[SHEAR iQ] To backfill savedAt on older sessions, run: backfillSav
   function aggregate(sessions, farmFilter){
     let totalSessionHours = 0;
     let totalShedStaffHours = 0;
+    let totalCrewHours = 0;
 
     const byFarm = new Map();   // farm -> { sessionHours, shedStaffHours }
     const byPerson = new Map(); // name|role -> { name, role, days:Set, totalHours }
@@ -2975,6 +2977,7 @@ console.info('[SHEAR iQ] To backfill savedAt on older sessions, run: backfillSav
 
       // Sum crew hours by role (for reference)
       let shedStaffHours = 0;
+      let sessionCrewHours = 0;
 
       const addPerson = (name, role, dayKey, hours) => {
         const key = `${name}|${role}`;
@@ -2988,9 +2991,11 @@ console.info('[SHEAR iQ] To backfill savedAt on older sessions, run: backfillSav
       eachPersonInSession(s, ({name, role, dateKey, hours})=>{
         addPerson(name, role, dateKey, hours);
         if (role === 'Shed Staff') shedStaffHours += hours;
+        sessionCrewHours += hours;
       });
 
       totalShedStaffHours += shedStaffHours;
+      totalCrewHours += sessionCrewHours;
 
       // By farm rollup
       const f = byFarm.get(farm) || { sessionHours:0, shedStaffHours:0 };
@@ -3015,6 +3020,7 @@ console.info('[SHEAR iQ] To backfill savedAt on older sessions, run: backfillSav
     return {
       totalSessionHours,
       totalShedStaffHours,
+      totalCrewHours,
       farmRows,
       personRows,
       monthMap: byMonth,
@@ -3044,7 +3050,7 @@ console.info('[SHEAR iQ] To backfill savedAt on older sessions, run: backfillSav
     renderPill(agg.totalSessionHours);
 
     // Render modal tables
-    renderSummary(agg.totalSessionHours, agg.totalShedStaffHours);
+    renderSummary(agg.totalSessionHours, agg.totalCrewHours, agg.totalShedStaffHours);
     renderByFarm(agg.farmRows);
     renderByPerson(agg.personRows);
     renderByMonth(agg.monthMap);


### PR DESCRIPTION
## Summary
- compute combined crew hours per session including multiple sessions on the same day
- display "Total Crew Hours" in hours-worked KPI summary table and describe metric

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a77080e028832193dd2194686bb7fe