### PR TITLE
fix: parse session date strings in local time

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -595,6 +595,11 @@ function initTop5ShearersWidget() {
     function sessionDateToJS(d) {
       if (!d) return null;
       if (typeof d === 'object' && d.toDate) return d.toDate();
+      if (typeof d === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(d)) {
+        const [y, m, day] = d.split('-').map(Number);
+        const dt = new Date(y, m - 1, day);
+        return isNaN(dt.getTime()) ? null : dt;
+      }
       const dt = new Date(d);
       return isNaN(dt.getTime()) ? null : dt;
     }
@@ -1010,6 +1015,11 @@ function initTop5ShedStaffWidget() {
     function sessionDateToJS(d) {
       if (!d) return null;
       if (typeof d === 'object' && d.toDate) return d.toDate();
+      if (typeof d === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(d)) {
+        const [y, m, day] = d.split('-').map(Number);
+        const dt = new Date(y, m - 1, day);
+        return isNaN(dt.getTime()) ? null : dt;
+      }
       const dt = new Date(d);
       return isNaN(dt.getTime()) ? null : dt;
     }
@@ -1340,6 +1350,12 @@ function initTop5FarmsWidget() {
 
     function sessionDateToJS(d) {
       if (!d) return null;
+      if (typeof d === 'object' && d.toDate) return d.toDate();
+      if (typeof d === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(d)) {
+        const [y, m, day] = d.split('-').map(Number);
+        const dt = new Date(y, m - 1, day);
+        return isNaN(dt.getTime()) ? null : dt;
+      }
       const dt = new Date(d);
       return isNaN(dt.getTime()) ? null : dt;
     }


### PR DESCRIPTION
## Summary
- ensure sessionDateToJS parses bare YYYY-MM-DD strings as local dates so current-year filters include today's sessions

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a76cbb9f008321a6b971e2325c8a53