### PR TITLE
Enable farm summary export for all users

### DIFF
--- a/public/tally.html
+++ b/public/tally.html
@@ -345,7 +345,8 @@
 
 <script src="xlsx.full.min.js"></script>
 <script type="module" src="auth.js"></script>
- <script src="/tally.js?v=help-in-tour-2"></script>
+<script src="/export.js"></script>
+<script src="/tally.js?v=help-in-tour-2"></script>
   </div> <!-- tallySheetView -->
 
 <div id="summaryView" class="view" style="display:none;">
@@ -428,7 +429,7 @@
     <thead><tr></tr></thead>
     <tbody></tbody>
   </table>
-  <button id="exportFarmSummaryBtn" class="main-button" data-help="Export the farm summary (contractor only).">Export Farm Summary</button>
+  <button id="exportFarmSummaryBtn" class="main-button" data-help="Export the farm summary.">Export Farm Summary</button>
 </div>
  
 <footer id="footer">Logged in as: <span id="userEmail">loading...</span></footer>

--- a/public/tally.js
+++ b/public/tally.js
@@ -2604,7 +2604,7 @@ function buildExportRows(data) {
 
 function updateUIForRole(role) {
     const admin = role === 'admin';
-    const ids = ['saveCloudBtn', 'saveBothBtn', 'loadCloudBtn', 'exportFarmSummaryBtn'];
+    const ids = ['saveCloudBtn', 'saveBothBtn', 'loadCloudBtn'];
     ids.forEach(id => {
         const el = document.getElementById(id);
         if (el) {


### PR DESCRIPTION
## Summary
- load export helpers on tally page
- allow all roles to use the export button

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7ca71d454832197678a3b2678d959