### PR TITLE
Format average session length in hours worked table

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -3030,7 +3030,7 @@ console.info('[SHEAR iQ] To backfill savedAt on older sessions, run: backfillSav
         <td>${r.farm}</td>
         <td>${hoursToHM(r.sessionHours)}</td>
         <td>${hoursToHM(r.shedStaffHours)}</td>
-        <td>${r.sessionCount ? formatHoursHM(r.sessionHours / r.sessionCount) : '—'}</td>
+        <td>${r.sessionCount ? hoursToHM(r.sessionHours / r.sessionCount) : '—'}</td>
       `;
       tblByFarm.appendChild(tr);
     });


### PR DESCRIPTION
## Summary
- Display average session length in the Hours Worked modal's By Farm table using `xh ym` format

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7cd716db083218f4f5f67a8784948