### PR TITLE
Refine days worked modal

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -374,19 +374,15 @@
               <h3>Summary</h3>
               <div id="kpiDWReliability" class="kpi-trend">
                 <div class="kpi-badges" id="kpiDWBadges" aria-live="polite">
-                  <span class="kpi-badge" id="kpiDWBestAttendance" hidden>Best: —</span>
-                  <span class="kpi-badge" id="kpiDWLowestAttendance" hidden>Lowest: —</span>
-                  <span class="kpi-badge" id="kpiDWLongestContract" hidden>Longest Contract: —</span>
+                  <span class="kpi-badge kpi-pill" id="kpiDWHighestAttendance" hidden>Highest Attendance: —</span>
+                  <span class="kpi-badge kpi-pill" id="kpiDWMostConsecutiveDays" hidden>Most Consecutive Days: —</span>
                 </div>
               </div>
               <table class="kpi-table">
                 <thead><tr><th>Metric</th><th>Count</th></tr></thead>
                 <tbody id="kpiDWSummary"></tbody>
               </table>
-              <small class="kpi-note">
-                <strong>Days Worked</strong> counts unique session dates (1 per calendar day).<br>
-                Per-person days are also unique per date — working multiple farms in one day still counts as 1.
-              </small>
+              <p class="kpi-note">Each work day is only counted once, even if multiple teams worked that day.</p>
             </section>
 
             <section>
@@ -428,8 +424,8 @@
               <h3>By Month</h3>
               <div id="kpiDWMonthTrend" class="kpi-trend">
                 <div class="kpi-badges" id="kpiDWMonthPeaks" aria-live="polite">
-                  <span class="kpi-badge" id="kpiDWBusiestMonth" hidden>Busiest: —</span>
-                  <span class="kpi-badge" id="kpiDWQuietestMonth" hidden>Quietest: —</span>
+                  <span class="kpi-badge kpi-pill" id="kpiDWBusiestMonth" hidden>Busiest: —</span>
+                  <span class="kpi-badge kpi-pill" id="kpiDWQuietestMonth" hidden>Quietest: —</span>
                 </div>
                 <div id="kpiDWMonthSpark" class="kpi-spark" role="img" aria-label="Monthly days-worked trend"></div>
               </div>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -3272,9 +3272,8 @@ console.info('[SHEAR iQ] To backfill savedAt on older sessions, run: backfillSav
   const tblByMonth = document.querySelector('#kpiDWByMonth tbody');
   const tblStreaks = document.querySelector('#kpiDWStreaks tbody');
   const reliabilityEl = document.getElementById('kpiDWReliability');
-  const bestAttendanceEl = document.getElementById('kpiDWBestAttendance');
-  const lowestAttendanceEl = document.getElementById('kpiDWLowestAttendance');
-  const longestContractEl = document.getElementById('kpiDWLongestContract');
+  const highestAttendanceEl = document.getElementById('kpiDWHighestAttendance');
+  const mostConsecutiveEl = document.getElementById('kpiDWMostConsecutiveDays');
   const monthTrendEl = document.getElementById('kpiDWMonthTrend');
   const monthSparkEl = document.getElementById('kpiDWMonthSpark');
   const busiestMonthEl = document.getElementById('kpiDWBusiestMonth');
@@ -3575,10 +3574,8 @@ console.info('[SHEAR iQ] To backfill savedAt on older sessions, run: backfillSav
     dashCache.kpiDaysWorked = text;
     saveDashCache();
   }
-  function renderSummary(total, above, below){
-    tbodySummary.innerHTML = `<tr><td>Days Worked</td><td>${total}</td></tr>`+
-      `<tr><td>People ≥20 above avg</td><td>${above}</td></tr>`+
-      `<tr><td>People ≥20 below avg</td><td>${below}</td></tr>`;
+  function renderSummary(total){
+    tbodySummary.innerHTML = `<tr><td>Days Worked</td><td>${total}</td></tr>`;
   }
   function renderByFarm(rows){
     const tbody = document.querySelector('#kpiDWByFarm tbody');
@@ -3613,15 +3610,15 @@ console.info('[SHEAR iQ] To backfill savedAt on older sessions, run: backfillSav
     attendanceArr.forEach(a=>{ exportExtras.set(`${a.name}|${a.role}`, {attendancePct:a.attendancePct}); });
 
     reliabilityEl && (reliabilityEl.hidden = agg.allDays.size === 0);
-    bestAttendanceEl && (bestAttendanceEl.hidden = true);
-    lowestAttendanceEl && (lowestAttendanceEl.hidden = true);
-    longestContractEl && (longestContractEl.hidden = true);
+    highestAttendanceEl && (highestAttendanceEl.hidden = true);
+    mostConsecutiveEl && (mostConsecutiveEl.hidden = true);
 
     if (agg.allDays.size && attendanceArr.length){
       const best = attendanceArr.reduce((a,b)=>b.attendancePct>a.attendancePct?b:a);
-      const worst = attendanceArr.reduce((a,b)=>b.attendancePct<a.attendancePct?b:a);
-      if (bestAttendanceEl) { bestAttendanceEl.textContent = `Best: ${best.name} (${best.attendancePct.toFixed(0)}%)`; bestAttendanceEl.hidden = false; }
-      if (lowestAttendanceEl) { lowestAttendanceEl.textContent = `Lowest: ${worst.name} (${worst.attendancePct.toFixed(0)}%)`; lowestAttendanceEl.hidden = false; }
+      if (highestAttendanceEl) {
+        highestAttendanceEl.textContent = `Highest Attendance: ${best.name} (${best.attendancePct.toFixed(0)}%)`;
+        highestAttendanceEl.hidden = false;
+      }
     }
 
     const streakRows = [];
@@ -3638,18 +3635,13 @@ console.info('[SHEAR iQ] To backfill savedAt on older sessions, run: backfillSav
 
     if (agg.allDays.size && streakRows.length){
       const bestStreak = streakRows.reduce((a,b)=> (b.length>a.length) || (b.length===a.length && b.startISO<a.startISO) ? b : a );
-      if (longestContractEl) {
-        longestContractEl.textContent = `Longest Contract: ${bestStreak.name} (${bestStreak.length} days, ${formatDate(bestStreak.startISO)}–${formatDate(bestStreak.endISO)})`;
-        longestContractEl.hidden = false;
+      if (mostConsecutiveEl) {
+        mostConsecutiveEl.textContent = `Most Consecutive Days: ${bestStreak.name} (${bestStreak.length} days, ${formatDate(bestStreak.startISO)}–${formatDate(bestStreak.endISO)})`;
+        mostConsecutiveEl.hidden = false;
       }
     }
-
-    const avgDays = agg.personRows.reduce((sum,p)=>sum+p.days,0)/(agg.personRows.length||1);
-    const aboveN = agg.personRows.filter(p=>p.days - avgDays >= 20).length;
-    const belowN = agg.personRows.filter(p=>avgDays - p.days >= 20).length;
-
     renderPill(agg.total);
-    renderSummary(agg.total, aboveN, belowN);
+    renderSummary(agg.total);
     renderByFarm(agg.farmRows);
     renderByPerson(agg.personRows);
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -1411,4 +1411,12 @@ button {
 .kpi-trend { margin: 8px 0 12px; }
 .kpi-badges { display:flex; gap:8px; flex-wrap:wrap; }
 .kpi-badge { font-size:12px; padding:2px 8px; border-radius:999px; background:#1f2937; }
+.kpi-modal .kpi-pill {
+  background-color: #f0f8ff;
+  border-radius: 20px;
+  padding: 6px 12px;
+  margin: 4px;
+  font-weight: bold;
+  display: inline-block;
+}
 .kpi-spark { height:36px; }


### PR DESCRIPTION
## Summary
- Retitle and simplify Days Worked summary pills, removing lowest attendance and highlighting highest attendance and consecutive-day streaks.
- Trim summary table to a single Days Worked row with an updated footnote.
- Introduce a modal-specific `.kpi-pill` style to make KPI pills stand out.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a82099c5348321ab78a21c8a6a00a2