### PR TITLE
feat: add monthly average for days worked

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -424,8 +424,9 @@
               <h3>By Month</h3>
               <div id="kpiDWMonthTrend" class="kpi-trend">
                 <div class="kpi-badges" id="kpiDWMonthPeaks" aria-live="polite">
-                  <span class="kpi-badge kpi-pill" id="kpiDWBusiestMonth" hidden>Busiest: —</span>
-                  <span class="kpi-badge kpi-pill" id="kpiDWQuietestMonth" hidden>Quietest: —</span>
+                  <span class="kpi-badge kpi-pill" id="kpiDWBusiestMonth" hidden>Busiest Month: —</span>
+                  <span class="kpi-badge kpi-pill" id="kpiDWQuietestMonth" hidden>Quietest Month: —</span>
+                  <span class="kpi-badge kpi-pill" id="kpiDWMonthlyAverage" hidden>Monthly Average: —</span>
                 </div>
                 <div id="kpiDWMonthSpark" class="kpi-spark" role="img" aria-label="Monthly days-worked trend"></div>
               </div>


### PR DESCRIPTION
## Summary
- add Monthly Average pill to Days Worked dashboard
- compute busiest, quietest, and average months
- include helper for summing values

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a828d964908321ba47e44d98215017