### PR TITLE
Ensure KPI pill text is readable

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1413,6 +1413,7 @@ button {
 .kpi-badge { font-size:12px; padding:2px 8px; border-radius:999px; background:#1f2937; }
 .kpi-modal .kpi-pill {
   background-color: #f0f8ff;
+  color: #1f2937;
   border-radius: 20px;
   padding: 6px 12px;
   margin: 4px;


### PR DESCRIPTION
## Summary
- add contrasting text color to KPI modal pills for readability

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a82b6a3ac88321b44915af9d4bf60f