### PR TITLE
Remove avg days column from Days Worked modal

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -391,9 +391,8 @@
                 <thead>
                   <tr>
                     <th>Farm</th>
-                    <th>Team Days</th>
+                    <th>Days Worked</th>
                     <th>Unique Workers</th>
-                    <th>Avg Days per Worker</th>
                   </tr>
                 </thead>
                 <tbody></tbody>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -3569,12 +3569,10 @@ console.info('[SHEAR iQ] To backfill savedAt on older sessions, run: backfillSav
     const farmRows = Array.from(farmDayMap.entries()).map(([farm, daySet]) => {
       const teamDays = daySet.size;
       const uniqueWorkers = (farmWorkersMap.get(farm) || new Set()).size;
-      const avg = uniqueWorkers ? (teamDays / uniqueWorkers) : 0;
       return {
         farm,
         teamDays,
-        uniqueWorkers,
-        avgDaysPerWorker: avg
+        uniqueWorkers
       };
     }).sort((a,b)=> b.teamDays - a.teamDays || a.farm.localeCompare(b.farm));
 
@@ -3607,7 +3605,6 @@ console.info('[SHEAR iQ] To backfill savedAt on older sessions, run: backfillSav
       <td>${escapeHtml(r.farm)}</td>
       <td>${r.teamDays}</td>
       <td>${r.uniqueWorkers}</td>
-      <td>${(Math.round(r.avgDaysPerWorker * 10) / 10).toFixed(1)}</td>
     </tr>
     `).join('');
   }


### PR DESCRIPTION
## Summary
- Drop "Avg Days per Worker" column from the Days Worked by Farm table
- Rename "Team Days" column to "Days Worked"
- Adjust data aggregation and rendering code to match new columns

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a82ce6813883219dd0d98b5ef15dd1