### PR TITLE
style: apply pill styling to total hours modal badges

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -327,8 +327,8 @@
                 <!-- Add this directly above the existing #kpiTHByMonth table -->
                 <div id="kpiTHMonthTrend" class="kpi-trend">
                   <div class="kpi-badges" id="kpiTHPeaks" aria-live="polite">
-                    <span class="kpi-badge" id="kpiTHBusiestBadge" hidden>Busiest: —</span>
-                    <span class="kpi-badge" id="kpiTHQuietestBadge" hidden>Quietest: —</span>
+                    <span class="kpi-badge kpi-pill" id="kpiTHBusiestBadge" hidden>Busiest: —</span>
+                    <span class="kpi-badge kpi-pill" id="kpiTHQuietestBadge" hidden>Quietest: —</span>
                   </div>
                   <div id="kpiTHMonthSpark" class="kpi-spark" role="img" aria-label="Monthly session-hours trend"></div>
                 </div>


### PR DESCRIPTION
## Summary
- style: match total-hours modal badge appearance to days-worked modal by adding `kpi-pill` class

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a82ed697588321b1aec496275e8060