### PR TITLE
feat: add change password option to dashboard welcome

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -633,6 +633,7 @@
         <li><strong>Farm Summary</strong>: Totals and comparisons by farm.</li>
         <li><strong>Guided Tour</strong>: Walk through the dashboard interactively from the Help menu.</li>
         <li><strong>Change Contractor PIN</strong>: Keep control and security tight.</li>
+        <li><strong>Change Password</strong>: Update your login password securely.</li>
         <li><strong>Settings / Preferences</strong>: Coming soon (not yet enabled).</li>
         <li><strong>Logout</strong>: Safely sign out.</li>
       </ul>
@@ -654,6 +655,7 @@
     <div class="dw-footer">
       <button class="dw-btn" id="dw-help">Open Help Menu</button>
       <button class="dw-btn" id="dw-start">Start Tour</button>
+      <button class="dw-btn" id="dw-change-password">Change Password</button>
       <button class="dw-btn" id="dw-save">Save</button>
       <button class="dw-btn primary" id="dw-ok">Got it</button>
     </div>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -2010,6 +2010,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const cbTourM   = document.getElementById('dw-enable-tour');
   const btnSaveM  = document.getElementById('dw-save');
   const btnStartM = document.getElementById('dw-start');
+  const btnChangePwM = document.getElementById('dw-change-password');
 
   // Help menu elements
   const helpMenu  = document.getElementById('dash-help-menu');
@@ -2116,6 +2117,12 @@ document.addEventListener('DOMContentLoaded', () => {
       syncHelpFromPrefs();
     }
     startDashboardTour();
+  });
+
+  // Change Password from modal
+  btnChangePwM?.addEventListener('click', () => {
+    persistFromModal({lockDone:true});
+    window.location.href = 'change-password.html';
   });
 
   // Keep “first-visit” rule intact elsewhere in your code:


### PR DESCRIPTION
## Summary
- add change password list item and button to dashboard welcome popup
- handle change password action in welcome modal script

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a85fd81e108321be066de48610990e