### PR TITLE
Highlight dashboard tour targets

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1866,6 +1866,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // === SIMPLE DASHBOARD TOUR ===
   // Minimal, self-contained tour with overlay + tooltip.
   let tourIndex = 0;
+  let tourCurrent = null;
   const tourOverlay = document.createElement('div');
   tourOverlay.className = 'siq-tour-overlay';
   document.body.appendChild(tourOverlay);
@@ -1929,6 +1930,12 @@ document.addEventListener('DOMContentLoaded', () => {
     const el = document.querySelector(step.sel);
     if (!el) return finishTour();
 
+    if (tourCurrent) {
+      tourCurrent.classList.remove('tt-highlight');
+    }
+    tourCurrent = el;
+    tourCurrent.classList.add('tt-highlight');
+
     el.scrollIntoView({ behavior: 'smooth', block: 'center' });
     tourOverlay.classList.add('active');
     tourTip.style.display = 'block';
@@ -1941,6 +1948,10 @@ document.addEventListener('DOMContentLoaded', () => {
   function finishTour() {
     tourOverlay.classList.remove('active');
     tourTip.style.display = 'none';
+    if (tourCurrent) {
+      tourCurrent.classList.remove('tt-highlight');
+      tourCurrent = null;
+    }
     localStorage.setItem('dashboard_welcome_done','true');
   }
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -1136,6 +1136,12 @@ button {
 }
 .siq-tour-btn.primary { background: #2a6df4; border-color: #2a6df4; }
 
+.tt-highlight {
+  outline: 3px solid rgba(255,255,255,0.5);
+  outline-offset: 3px;
+  border-radius: 8px;
+}
+
 /* Shed Staff widget: keep hours on one line and size sanely on all screens */
 #top5-shedstaff .lb-value {
   white-space: nowrap;                 /* never wrap */


### PR DESCRIPTION
## Summary
- highlight focused elements during dashboard tour
- add `.tt-highlight` styles for guided tours

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a86ac710e083219fcea1f4bd1583c1