### PR TITLE
Stack KPI pills vertically on narrow screens

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1373,6 +1373,13 @@ button {
   font-size: 0.8rem;
   color: #39ff14;
 }
+
+@media (max-width: 480px) {
+  #kpiBar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
 .kpi-meta { font-size: .75rem; opacity: .7; }
 
 /* Modal */


### PR DESCRIPTION
## Summary
- Ensure KPI pills stack vertically on small screens without stretching full width

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a870973c6883218da054c4df3b3a91