### PR TITLE
feat: expand tally sheet tour overview

### DIFF
--- a/public/tally.html
+++ b/public/tally.html
@@ -205,7 +205,7 @@
   <button class="tab-button" data-view="stationSummaryView" data-help="Summarize a farm across dates or all time.">Farm Summary</button>
   <button id="back-to-dashboard-btn" class="tab-button" style="display: none;" data-help="Go back to the Contractor Dashboard.">Return to Dashboard</button>
   </div>
-<div id="tallySheetView" class="view">
+<div id="tallySheetView" class="view" data-help="Welcome to the Tally Sheet — the engine room of SHEΔR iQ. This is where you capture all the key data from the shearing day. When you start a new session, a setup prompt appears where you choose how many shearers, how many tally rows per shearer, and how many shed staff are needed. You’ll also select whether the day follows an 8-hour or 9-hour schedule, and set the lunch break duration to match your team.<br/><br/>Each shearer has flexible tally input — not limited to just four runs. Add as many rows as needed to match how your team works. Every row records both the sheep tally and the sheep type. Below the tally table is the Shed Staff section, where you can enter total hours worked for each rousie, presser, or other support crew member.<br/><br/>Start and Finish times are used to automatically calculate hours worked. If someone works through a break (like lunch), simply enter their times and when prompted, confirm that they worked through — the app will add the appropriate time to their hours for you. You can also toggle between 24‑hour and 12‑hour time views depending on your preference.<br/><br/>All fields — including dropdowns like sheep types, team leaders, and comb types — can be typed into manually. Anything you enter will automatically be added to the dropdown list, saving it for future use.<br/><br/>When you tap Save, the system cleans up your data automatically — removing any empty rows or unused fields — so your exports stay tidy and professional. You can export to CSV instantly, or revisit and reload saved sessions at any time.">
 <div class="logo-container">
       <img src="logo.png" alt="SHEΔR iQ logo" />
       <h2 id="app-title">Tally Processor</h2>
@@ -253,7 +253,7 @@
   <button id="add-count-btn" data-help="Add a new tally run row." onclick="addCount()">Add Count</button>
   <button id="remove-count-btn" data-help="Remove the last tally run." onclick="removeCount()">Remove Count</button>
 </div>
-<table id="tallyTable" data-help="Enter tallies by run and stand. Add sheep type for each run.">
+<table id="tallyTable">
 <thead>
 <tr id="headerRow">
 <th>Count #</th>

--- a/public/tally.js
+++ b/public/tally.js
@@ -3607,6 +3607,10 @@ function initTallyTooltips() {
       return;
     }
     guidedList = Array.from(document.querySelectorAll('#tabNav [data-help], #tallySheetView [data-help], #summaryView [data-help], #stationSummaryView [data-help]')).filter(el => !el.disabled);
+    const tallyContainer = document.getElementById('tallySheetView');
+    if (tallyContainer && tallyContainer.dataset.help) {
+      guidedList.unshift(tallyContainer);
+    }
     if (!guidedList.length) return;
     guidedMode = true;
     guidedIndex = 0;


### PR DESCRIPTION
## Summary
- add a comprehensive Tally Sheet tour step explaining session setup, flexible rows, break logic, manual entries, auto cleanup, and exports
- ensure the main tally container is the first step in the guided tour

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8770e457c83218630570300e2cff2