### PR TITLE
Handle offline role lookup

### DIFF
--- a/public/auth-check.js
+++ b/public/auth-check.js
@@ -11,11 +11,19 @@ firebase.auth().onAuthStateChanged(async function (user) {
 
   // Step 1: Check if user is a contractor
   const contractorRef = db.collection("contractors").doc(userUid);
-  const contractorSnap = await contractorRef.get();
+  let contractorSnap;
+  try {
+    contractorSnap = await contractorRef.get();
+  } catch (err) {
+    console.error("[auth-check] \u274c Failed to fetch contractor record:", err);
+    handleOfflineRedirect();
+    return;
+  }
 
   if (contractorSnap.exists && contractorSnap.data().role === "contractor") {
     console.log("[auth-check] \u2705 User is a contractor");
     localStorage.setItem("contractor_id", userUid);
+    localStorage.setItem("role", "contractor");
     await waitForContractorIdAndRedirect();
     return;
   }
@@ -23,10 +31,17 @@ firebase.auth().onAuthStateChanged(async function (user) {
   // Step 2: Search all contractor/staff subcollections for this staff UID
   console.log("[auth-check] \ud83d\udd0d Not a contractor, searching staff subcollections...");
 
-  const staffQuery = await db
-    .collectionGroup("staff")
-    .where(firebase.firestore.FieldPath.documentId(), "==", userUid)
-    .get();
+  let staffQuery;
+  try {
+    staffQuery = await db
+      .collectionGroup("staff")
+      .where(firebase.firestore.FieldPath.documentId(), "==", userUid)
+      .get();
+  } catch (err) {
+    console.error("[auth-check] \u274c Failed to fetch staff record:", err);
+    handleOfflineRedirect();
+    return;
+  }
 
   if (!staffQuery.empty) {
     const docSnap = staffQuery.docs[0];
@@ -42,6 +57,7 @@ firebase.auth().onAuthStateChanged(async function (user) {
         if (contractorId) {
           try {
             localStorage.setItem("contractor_id", contractorId);
+            localStorage.setItem("role", role);
             window.location.href = "tally.html";
           } catch (e) {
             console.error("\u274c Failed to set contractor_id in localStorage:", e);
@@ -77,4 +93,15 @@ async function waitForContractorIdAndRedirect(maxWaitMs = 2000) {
   }
   console.error('[auth-check.js] \u23F3 Timeout waiting for contractor_id');
   window.location.href = 'login.html';
+}
+
+function handleOfflineRedirect() {
+  const storedRole = localStorage.getItem('role');
+  const contractorId = localStorage.getItem('contractor_id');
+  if (storedRole && contractorId) {
+    console.warn('[auth-check] \u26a0\ufe0f Offline. Using cached data for role:', storedRole);
+    window.location.href = 'tally.html';
+  } else {
+    alert('You appear to be offline. Please reconnect.');
+  }
 }

--- a/public/firebase-init.js
+++ b/public/firebase-init.js
@@ -10,5 +10,13 @@
 
   if (typeof firebase !== 'undefined' && (!firebase.apps || !firebase.apps.length)) {
     firebase.initializeApp(firebaseConfig);
+    if (firebase.firestore) {
+      firebase
+        .firestore()
+        .enableIndexedDbPersistence()
+        .catch(function (err) {
+          console.warn('Failed to enable persistence', err);
+        });
+    }
   }
 })();


### PR DESCRIPTION
## Summary
- wrap Firestore `get` calls in `auth-check.js` with try/catch
- fall back to cached role and contractor ID or alert when offline
- enable Firestore IndexedDB persistence in `firebase-init.js`

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a87a5dc1a883218ded7430b7f23099