### PR TITLE
Handle offline fallback in auth-check

### DIFF
--- a/public/auth-check.js
+++ b/public/auth-check.js
@@ -96,12 +96,31 @@ async function waitForContractorIdAndRedirect(maxWaitMs = 2000) {
 }
 
 function handleOfflineRedirect() {
+  const overlay = document.getElementById('loading-overlay');
+  if (overlay) {
+    overlay.style.display = 'none';
+  }
+
   const storedRole = localStorage.getItem('role');
   const contractorId = localStorage.getItem('contractor_id');
+
   if (storedRole && contractorId) {
     console.warn('[auth-check] \u26a0\ufe0f Offline. Using cached data for role:', storedRole);
     window.location.href = 'tally.html';
   } else {
-    alert('You appear to be offline. Please reconnect.');
+    const msg = document.createElement('div');
+    msg.textContent = 'You appear to be offline. Please reconnect.';
+    const retry = document.createElement('button');
+    retry.textContent = 'Retry';
+    retry.addEventListener('click', () => location.reload());
+    const container = document.createElement('div');
+    container.style.marginTop = '20px';
+    container.style.textAlign = 'center';
+    container.appendChild(msg);
+    container.appendChild(retry);
+    document.body.appendChild(container);
   }
 }
+
+// Reload automatically when connection is restored
+window.addEventListener('online', () => location.reload());


### PR DESCRIPTION
## Summary
- Hide auth-check loading overlay when offline and add retry button
- Reload page automatically when connection is restored

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8808277c883219ab24516aa5a87e2