### PR TITLE
fix: ensure dashboard welcome popup fits on mobile screens

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1033,7 +1033,8 @@ button {
   border: 1px solid rgba(255,255,255,0.1);
   border-radius: 12px;
   box-shadow: 0 12px 40px rgba(0,0,0,0.5);
-  width: min(560px, 92vw);
+  /* Ensure modal fits smaller viewports by accounting for padding/border */
+  width: min(560px, calc(100vw - 34px));
   max-height: min(80vh, 720px);
   display: flex;
   flex-direction: column;
@@ -1077,7 +1078,10 @@ button {
   gap: 8px;
   margin-top: 10px;
 }
-#dashboard-welcome-modal .dw-row label { white-space: nowrap; }
+#dashboard-welcome-modal .dw-row label {
+  /* Allow wrapping so long labels don't cause horizontal overflow on mobile */
+  white-space: normal;
+}
 
 #dashboard-welcome-modal .dw-footer {
   padding: 12px 16px;


### PR DESCRIPTION
## Summary
- adjust welcome modal width calculation so padding and borders don't overflow on small viewports
- allow labels inside the welcome modal to wrap, preventing horizontal scrolling

## Testing
- `npm test` *(fails: missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8805d7e688321a3a29f984b8a63a4