### PR TITLE
Redirect offline users to login and cache login page

### DIFF
--- a/public/auth-check.js
+++ b/public/auth-check.js
@@ -103,5 +103,6 @@ function handleOfflineRedirect() {
     window.location.href = 'tally.html';
   } else {
     alert('You appear to be offline. Please reconnect.');
+    window.location.href = 'login.html';
   }
 }

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -7,7 +7,7 @@ const FILES_TO_CACHE = [
   'auth-check.html',
   'dashboard.html',
   'tally.html',
-  'login.html',
+  'login.html', // cache login page for offline redirect
 
   // App assets (keep existing names; do NOT rename)
   'styles.css',


### PR DESCRIPTION
## Summary
- Redirect users to `login.html` when offline and no cached role is available.
- Document login page in service worker cache list for offline availability.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a88084f994832197563d009c420ea5