### PR TITLE
Remove change password button from dashboard welcome popup

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -655,7 +655,6 @@
     <div class="dw-footer">
       <button class="dw-btn" id="dw-help">Open Help Menu</button>
       <button class="dw-btn" id="dw-start">Start Tour</button>
-      <button class="dw-btn" id="dw-change-password">Change Password</button>
       <button class="dw-btn" id="dw-save">Save</button>
       <button class="dw-btn primary" id="dw-ok">Got it</button>
     </div>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -2021,7 +2021,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const cbTourM   = document.getElementById('dw-enable-tour');
   const btnSaveM  = document.getElementById('dw-save');
   const btnStartM = document.getElementById('dw-start');
-  const btnChangePwM = document.getElementById('dw-change-password');
 
   // Help menu elements
   const helpMenu  = document.getElementById('dash-help-menu');
@@ -2129,13 +2128,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     startDashboardTour();
   });
-
-  // Change Password from modal
-  btnChangePwM?.addEventListener('click', () => {
-    persistFromModal({lockDone:true});
-    window.location.href = 'change-password.html';
-  });
-
   // Keep “first-visit” rule intact elsewhere in your code:
   // shouldShowWelcome() must check welcomeEnabled && !welcomeDone
   // If you want "Got it" to also mark done when “Don’t show again” is ticked,


### PR DESCRIPTION
## Summary
- Remove obsolete Change Password button from dashboard welcome popup
- Clean up unused references to Change Password handler

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a882f37ed483218e8868816987e186