### PR TITLE
feat: add temporary force offline toggle

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -100,6 +100,54 @@
       });
     })();
   </script>
+  <style>
+    /* Temporary settings toggle */
+    .setting-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin: 8px 0;
+    }
+    .switch {
+      position: relative;
+      display: inline-block;
+      width: 40px;
+      height: 20px;
+    }
+    .switch input {
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+    .slider {
+      position: absolute;
+      cursor: pointer;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: #555;
+      transition: 0.2s;
+      border-radius: 20px;
+    }
+    .slider:before {
+      position: absolute;
+      content: "";
+      height: 16px;
+      width: 16px;
+      left: 2px;
+      bottom: 2px;
+      background: #fff;
+      transition: 0.2s;
+      border-radius: 50%;
+    }
+    .switch input:checked + .slider {
+      background: #2196F3;
+    }
+    .switch input:checked + .slider:before {
+      transform: translateX(20px);
+    }
+  </style>
 </head>
 <body>
 <!-- DASHBOARD HELP BUTTON -->
@@ -118,6 +166,13 @@
     <label class="dhm-row">
       <input type="checkbox" id="toggle-tour"> Enable Dashboard Tour
     </label>
+    <div class="setting-row">
+      <label class="switch">
+        <input id="forceOfflineToggle" type="checkbox">
+        <span class="slider"></span>
+      </label>
+      <span class="label-text">Force Offline (test)</span>
+    </div>
     <div class="dhm-actions">
       <button id="btnStartTour" class="dhm-btn">Start Tour</button>
       <button id="btnSkipTour" class="dhm-btn">Skip Tour</button>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -2827,6 +2827,46 @@ console.info('[SHEAR iQ] To backfill savedAt on older sessions, run: backfillSav
   if (SessionStore.getAll().length) refresh();
 })();
 
+// === Temporary Force Offline Toggle ===
+function showDashboardToast(msg) {
+  let toast = document.getElementById('dash-toast');
+  if (!toast) {
+    toast = document.createElement('div');
+    toast.id = 'dash-toast';
+    toast.style.position = 'fixed';
+    toast.style.bottom = '20px';
+    toast.style.left = '50%';
+    toast.style.transform = 'translateX(-50%)';
+    toast.style.background = 'rgba(20,20,20,0.95)';
+    toast.style.color = '#fff';
+    toast.style.padding = '8px 12px';
+    toast.style.borderRadius = '6px';
+    toast.style.fontSize = '14px';
+    toast.style.zIndex = '2147483647';
+    toast.style.display = 'none';
+    document.body.appendChild(toast);
+  }
+  toast.textContent = msg;
+  toast.style.display = 'block';
+  clearTimeout(showDashboardToast._t);
+  showDashboardToast._t = setTimeout(() => { toast.style.display = 'none'; }, 4000);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const forceToggle = document.getElementById('forceOfflineToggle');
+  if (!forceToggle) return;
+  forceToggle.checked = localStorage.getItem('force_offline') === '1';
+  forceToggle.addEventListener('change', () => {
+    if (forceToggle.checked) {
+      localStorage.setItem('force_offline', '1');
+      showDashboardToast('Force Offline on. Close the app, enable airplane mode, and open from the home-screen icon to test.');
+    } else {
+      localStorage.removeItem('force_offline');
+      showDashboardToast('Force Offline off.');
+    }
+  });
+});
+
 // === KPI: Total Hours (Session Hours for the year) ===
 (function setupKpiTotalHours(){
   const pill = document.getElementById('kpiTotalHours');


### PR DESCRIPTION
## Summary
- add Force Offline switch in dashboard help settings
- persist force_offline flag and show toast messages

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b94d418e488321b79e33ee4df50e67