### PR TITLE
feat: add contractor offline safe mode

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -149,6 +149,18 @@
       transform: translateX(20px);
     }
   </style>
+  <style>
+    body.offline-mode .loading-overlay,
+    body.offline-mode .boot-overlay,
+    body.offline-mode .boot-gate,
+    body.offline-mode #loading-overlay,
+    body.offline-mode #dashboardOverlay,
+    body.offline-mode .blocker {
+      pointer-events: none !important;
+      opacity: 0 !important;
+      display: none !important;
+    }
+  </style>
 </head>
 <body>
   <script>


### PR DESCRIPTION
## Summary
- add offline helpers and safe-mode boot for contractor dashboard
- skip heavy widget initialization and bind offline navigation when offline
- hide blocking overlays via CSS when body.offline-mode is set

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9600748d48321896081ecd7318f9f