### PR TITLE
Add on-screen debug banner for offline diagnostics

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -164,6 +164,65 @@
 </head>
 <body>
   <script>
+    (function(){
+      var banner = document.createElement('div');
+      banner.id = 'dbg-banner';
+      Object.assign(banner.style, {
+        position: 'fixed',
+        top: '0',
+        left: '0',
+        background: '#ff1493',
+        color: '#000',
+        fontWeight: 'bold',
+        padding: '4px 8px',
+        zIndex: '2147483647'
+      });
+      document.body.appendChild(banner);
+
+      window.DBG = window.DBG || {};
+      var DBG = window.DBG;
+      DBG.banner = banner;
+      DBG.messages = [];
+
+      DBG.update = function(){
+        var parts = [];
+        parts.push('onLine:' + navigator.onLine);
+        parts.push('jsLoaded:' + (DBG.jsLoaded ? 'true' : 'false'));
+        var ov = document.getElementById('loading-overlay');
+        if (ov) {
+          var st = getComputedStyle(ov);
+          parts.push('overlay:' + st.display + ',' + st.pointerEvents);
+        } else {
+          parts.push('overlay:none');
+        }
+        if (DBG.domContentLoadedTS) parts.push('DOMContentLoaded:' + DBG.domContentLoadedTS);
+        if (DBG.windowLoadTS) parts.push('load:' + DBG.windowLoadTS);
+        if (DBG.messages.length) parts = parts.concat(DBG.messages);
+        banner.textContent = parts.join(' | ');
+      };
+
+      DBG.addMessage = function(msg){
+        DBG.messages.push(msg);
+        DBG.update();
+      };
+
+      document.addEventListener('DOMContentLoaded', function(){
+        DBG.domContentLoadedTS = Date.now();
+        DBG.update();
+      });
+
+      window.addEventListener('load', function(){
+        DBG.windowLoadTS = Date.now();
+        DBG.update();
+      });
+
+      window.addEventListener('online', DBG.update);
+      window.addEventListener('offline', DBG.update);
+
+      DBG.update();
+    })();
+  </script>
+  <script>
     // Ensure this runs immediately, even offline
     (function() {
       const isOffline = !navigator.onLine || localStorage.getItem('force_offline') === '1';

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1,3 +1,25 @@
+window.DBG = window.DBG || {};
+window.DBG.jsLoaded = true;
+if (window.DBG.addMessage) {
+  window.DBG.addMessage('dashboard.js loaded');
+} else if (window.DBG.banner) {
+  window.DBG.banner.textContent += ' | dashboard.js loaded';
+}
+if (window.DBG.update) window.DBG.update();
+
+window.addEventListener('error', function(e){
+  if (window.DBG && window.DBG.addMessage) {
+    window.DBG.addMessage('error: ' + (e.message || e));
+  }
+});
+
+window.addEventListener('unhandledrejection', function(e){
+  if (window.DBG && window.DBG.addMessage) {
+    var msg = e.reason && e.reason.message ? e.reason.message : e.reason;
+    window.DBG.addMessage('unhandled: ' + msg);
+  }
+});
+
 // ===== Dashboard welcome modal: show ONCE EVER =====
 
 // Returns true if we should show the dashboard welcome on this visit


### PR DESCRIPTION
## Summary
- Add hot pink debug banner to dashboard with connectivity, script load, overlay visibility, and load event timestamps
- Flag dashboard.js load and surface errors via banner

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b967a6843c832199e90eaf5a07a8b1