### PR TITLE
Prevent offline overlays from blocking taps on dashboard

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -150,19 +150,77 @@
     }
   </style>
   <style>
+    /* When offline, never let overlays block input */
+    body.offline-mode #loading-overlay,
     body.offline-mode .loading-overlay,
     body.offline-mode .boot-overlay,
-    body.offline-mode .boot-gate,
-    body.offline-mode #loading-overlay,
+    body.offline-mode .boot-hiding,
     body.offline-mode #dashboardOverlay,
-    body.offline-mode .blocker {
-      pointer-events: none !important;
-      opacity: 0 !important;
+    body.offline-mode .modal-backdrop,
+    body.offline-mode .blocker,
+    body.offline-mode .page-mask {
       display: none !important;
+      opacity: 0 !important;
+      pointer-events: none !important;
+      visibility: hidden !important;
     }
-  </style>
-</head>
+    </style>
+  </head>
 <body>
+  <script>
+  (function(){
+    var isForced = localStorage.getItem('force_offline') === '1';
+    var offline = !navigator.onLine || isForced;
+    var role = localStorage.getItem('user_role');
+    if (!(offline && role === 'contractor')) return;
+
+    // Mark offline mode so CSS guard applies
+    document.addEventListener('DOMContentLoaded', function(){ document.body.classList.add('offline-mode'); });
+    document.body.classList.add('offline-mode');
+
+    function hideBlockers(){
+      [
+        '#loading-overlay','.loading-overlay','.boot-overlay','.boot-hiding',
+        '#dashboardOverlay','.modal-backdrop','.blocker','.page-mask'
+      ].forEach(function(sel){
+        document.querySelectorAll(sel).forEach(function(el){
+          el.style.display = 'none';
+          el.style.opacity = '0';
+          el.style.pointerEvents = 'none';
+          if (el.classList) el.classList.remove('boot-hiding');
+          el.removeAttribute && el.removeAttribute('aria-hidden');
+        });
+      });
+      // Ensure root remains interactive
+      var root = document.getElementById('app') || document.body;
+      root.style.pointerEvents = 'auto';
+      root.style.opacity = '1';
+    }
+
+    // Run immediately
+    hideBlockers();
+
+    // Watch for anything trying to re-add or restyle overlays
+    var mo = new MutationObserver(function(){
+      hideBlockers();
+    });
+    mo.observe(document.documentElement, { childList:true, subtree:true, attributes:true, attributeFilter:['class','style','aria-hidden'] });
+
+    // Belt & braces: re-apply every 600ms for a few seconds
+    var n=0, t=setInterval(function(){ hideBlockers(); if (++n>12) clearInterval(t); }, 600);
+
+    // Visible fallback link to Tally (works even if other JS fails)
+    if (!document.getElementById('offlineTallyLink')) {
+      var a=document.createElement('a');
+      a.id='offlineTallyLink';
+      a.href='/tally.html';
+      a.textContent='Open Tally (Offline)';
+      a.style.cssText='position:fixed;top:10px;right:10px;z-index:2147483647;background:rgba(0,0,0,.7);color:#fff;padding:6px 10px;border-radius:6px;font:13px system-ui;text-decoration:none';
+      a.addEventListener('click', function(e){ e.preventDefault(); e.stopPropagation(); location.href='/tally.html'; }, {passive:false});
+      document.body.appendChild(a);
+    }
+  })();
+  </script>
   <script>
     (function(){
       var banner = document.createElement('div');


### PR DESCRIPTION
## Summary
- Add CSS guard to hide loading overlays when offline
- Add early script to enforce overlay removal and show offline Tally link

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b96f5b83388321a5679279af2c403c