### PR TITLE
Fix offline Start New Day navigation

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -107,16 +107,17 @@ function showOfflineToastOnce(msg){
 function handleStartNewDayClick(e){
   e.preventDefault();
   e.stopPropagation();
+  if (e.stopImmediatePropagation) e.stopImmediatePropagation();
   if (isReallyOffline()) {
     caches.match('/tally.html').then(res => {
       if (res) {
-        location.href = '/tally.html';
+        location.assign('/tally.html');
       } else {
         alert('Tally page not available offline. Please connect to the internet at least once to cache this page.');
       }
     });
   } else {
-    location.href = '/tally.html';
+    location.assign('/tally.html');
   }
 }
 
@@ -1866,10 +1867,10 @@ document.addEventListener('DOMContentLoaded', () => {
       }
 
       const btnStartNewDay = document.getElementById('btnStartNewDay');
-      if (btnStartNewDay) {
+      if (btnStartNewDay && !isReallyOffline()) {
         btnStartNewDay.addEventListener('click', () => {
           sessionStorage.setItem('launch_override', 'tally');
-          window.location.href = 'tally.html?newDay=true';
+          window.location.href = '/tally.html?newDay=true';
         });
       }
 

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -58,17 +58,20 @@ self.addEventListener('activate', event => {
 self.addEventListener('fetch', event => {
   if (event.request.mode === 'navigate') {
     event.respondWith((async () => {
-      const path = new URL(event.request.url).pathname;
+      const url = new URL(event.request.url);
+      const path = url.pathname;
+      const isTally = path.endsWith('/tally.html');
+      const isDash = path.endsWith('/dashboard.html');
       try {
         const net = await fetch(event.request);
-        if (path.endsWith('/tally.html')) {
+        if (isTally) {
           const cache = await caches.open(CACHE_NAME);
           cache.put('/tally.html', net.clone());
         }
         return net;
       } catch (err) {
         const cache = await caches.open(CACHE_NAME);
-        if (path.endsWith('/tally.html')) {
+        if (isTally) {
           const cachedTally = await cache.match('/tally.html');
           if (cachedTally) {
             console.log('[service-worker] Offline: serving cached tally.html');
@@ -76,7 +79,7 @@ self.addEventListener('fetch', event => {
           }
           return new Response('<!doctype html><meta charset="utf-8"><title>Offline</title><body style="background:#000;color:#fff;font-family:sans-serif;display:flex;align-items:center;justify-content:center;height:100vh;"><div>Tally page not available offline.</div></body>', { headers: { 'Content-Type': 'text/html' }});
         }
-        if (path.endsWith('/dashboard.html')) {
+        if (isDash) {
           const cachedDash = await cache.match('/dashboard.html');
           if (cachedDash) {
             console.log('[service-worker] Offline: serving cached dashboard.html');


### PR DESCRIPTION
## Summary
- Ensure Start New Day offline handler suppresses other listeners and always navigates using absolute URL
- Only register online Start New Day listener when online
- Normalize service worker navigation handling for tally/dashboard routes

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b9816780f083219f3b3b96e7dfb1df