### PR TITLE
Ensure offline PWA launch goes straight to Tally

### DIFF
--- a/public/auth-check.js
+++ b/public/auth-check.js
@@ -128,22 +128,27 @@ firebase.auth().onAuthStateChanged(async function (user) {
 
   const result = await resolveRoleOfflineFirst(user);
 
-  if (result.role === 'contractor') {
-    if (isReallyOffline()) {
+    if (result.role === 'contractor') {
+      if (isReallyOffline()) {
+        if (window.bootBannerAppend) window.bootBannerAppend('auth-check.js: contractor+OFFLINE -> /tally.html');
+        window.location.href = 'tally.html';
+      } else {
+        if (window.bootBannerAppend) window.bootBannerAppend('auth-check.js: contractor+ONLINE -> /dashboard.html');
+        window.location.href = 'dashboard.html';
+      }
+    } else if (result.role === 'staff') {
+      if (window.bootBannerAppend) window.bootBannerAppend('auth-check.js: staff -> /tally.html');
       window.location.href = 'tally.html';
     } else {
-      window.location.href = 'dashboard.html';
+      if (isReallyOffline()) {
+        if (window.bootBannerAppend) window.bootBannerAppend('auth-check.js: unknown+OFFLINE -> /tally.html');
+        sessionStorage.setItem('offline_banner', 'Offline mode (role not verified)');
+        window.location.href = 'tally.html';
+      } else {
+        if (window.bootBannerAppend) window.bootBannerAppend('auth-check.js: unknown+ONLINE -> handleOfflineRedirect');
+        handleOfflineRedirect();
+      }
     }
-  } else if (result.role === 'staff') {
-    window.location.href = 'tally.html';
-  } else {
-    if (isReallyOffline()) {
-      sessionStorage.setItem('offline_banner', 'Offline mode (role not verified)');
-      window.location.href = 'tally.html';
-    } else {
-      handleOfflineRedirect();
-    }
-  }
 
   refreshRoleOnline(user);
 });

--- a/public/boot-router.js
+++ b/public/boot-router.js
@@ -1,0 +1,52 @@
+(function(){
+  const page = /tally\.html/i.test(location.pathname) ? 'TALLY' : 'DASHBOARD';
+  const banner = document.createElement('div');
+  banner.id = 'boot-banner';
+  Object.assign(banner.style, {
+    background: '#ff69b4',
+    color: '#000',
+    fontWeight: 'bold',
+    padding: '4px 6px',
+    position: 'fixed',
+    top: '0',
+    left: '0',
+    zIndex: '2147483647'
+  });
+  function update(extra){
+    banner.textContent = page + ' | __REAL_OFFLINE__=' + window.__REAL_OFFLINE__ + (extra? ' | ' + extra : '');
+  }
+  window.__BOOT_BANNER__ = banner;
+  window.bootBannerAppend = function(msg){
+    if (banner.textContent) banner.textContent += ' | ' + msg;
+    else banner.textContent = msg;
+  };
+  document.addEventListener('DOMContentLoaded', function(){
+    document.body.insertBefore(banner, document.body.firstChild);
+    update();
+    const prev = sessionStorage.getItem('debug_redirect');
+    if (prev){
+      bootBannerAppend(prev);
+      sessionStorage.removeItem('debug_redirect');
+    }
+  });
+
+  function realOffline(){
+    if (localStorage.getItem('force_offline') === '1') return Promise.resolve(true);
+    const controller = new AbortController();
+    const t = setTimeout(()=>controller.abort(),1200);
+    return fetch('/manifest.json', {method:'HEAD',cache:'no-store',signal:controller.signal}).then(()=>{
+      clearTimeout(t); return false;
+    }).catch(()=>{ clearTimeout(t); return true; });
+  }
+
+  realOffline().then(off=>{
+    window.__REAL_OFFLINE__ = off;
+    update();
+    const role = (localStorage.getItem('user_role')||'').toLowerCase();
+    if (role === 'contractor' && off && !/tally\.html$/i.test(location.pathname)){
+      sessionStorage.setItem('debug_redirect','boot-router.js→/tally.html');
+      bootBannerAppend('redirect→/tally.html (boot-router.js)');
+      location.replace('/tally.html');
+    }
+  });
+})();

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <script src="/sw-init.js"></script>
+  <head>
+    <script src="/sw-init.js"></script>
+    <script src="boot-router.js"></script>
   <!-- First paint: dark background + no-flash gate -->
   <style>
     /* Match the app's dark theme color */
@@ -167,6 +168,7 @@
     </style>
   </head>
 <body>
+  <div id="boot-banner"></div>
   <script>
 (function(){
   // ---- Robust offline detector ----

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -58,10 +58,10 @@ self.addEventListener('activate', event => {
 self.addEventListener('fetch', event => {
   if (event.request.mode === 'navigate') {
     event.respondWith((async () => {
-      const url = new URL(event.request.url);
-      const path = url.pathname;
-      const isTally = path.endsWith('/tally.html');
-      const isDash = path.endsWith('/dashboard.html');
+        const url = new URL(event.request.url);
+        const path = url.pathname.toLowerCase(); // ignores query/hash
+        const isTally = path.endsWith('/tally.html');
+        const isDash = path.endsWith('/dashboard.html');
       try {
         const net = await fetch(event.request);
         if (isTally) {

--- a/public/tally.html
+++ b/public/tally.html
@@ -1,8 +1,9 @@
  <!DOCTYPE html>
 
 <html lang="en">
-<head>
-<script src="/sw-init.js"></script>
+  <head>
+  <script src="/sw-init.js"></script>
+  <script src="boot-router.js"></script>
 <!-- First paint: dark background + no-flash gate -->
 <style>
   /* Match the app's dark theme color */
@@ -198,6 +199,7 @@
 </script>
 </head>
 <body>
+  <div id="boot-banner"></div>
 <script>
   // Safety: if CSS hides the page at boot (e.g. .boot-hiding), unhide after 1200ms no matter what.
   setTimeout(() => { document.documentElement.classList.remove('boot-hiding'); }, 1200);


### PR DESCRIPTION
## Summary
- add boot-router.js for early offline routing and pink debug banner
- log auth-check decisions to on-screen banner
- normalize service worker path check for tally/dashboard

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9906c72588321a5145fccb2218dd6