### PR TITLE
Handle boot redirect for offline contractors

### DIFF
--- a/public/boot-router.js
+++ b/public/boot-router.js
@@ -44,6 +44,7 @@
     update();
     const role = (localStorage.getItem('user_role')||'').toLowerCase();
     if (role === 'contractor' && off && !/tally\.html$/i.test(location.pathname)){
+      sessionStorage.setItem('boot_router_redirect','tally');
       sessionStorage.setItem('debug_redirect','boot-router.js→/tally.html');
       bootBannerAppend('redirect→/tally.html (boot-router.js)');
       location.replace('/tally.html');

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -85,10 +85,12 @@
 
       // One-time bypass set by buttons before navigating
       var launchOverride = (sessionStorage.getItem('launch_override') || '').toLowerCase();
+      var bootRedirected = sessionStorage.getItem('boot_router_redirect') === 'tally';
+      if (bootRedirected) sessionStorage.removeItem('boot_router_redirect');
       if (hasExplicitIntent || launchOverride === 'tally' || launchOverride === 'any') {
         // consume the one-time bypass so it doesn't affect later launches
         sessionStorage.removeItem('launch_override');
-      } else if (cold && want && here && want !== here) {
+      } else if (!bootRedirected && cold && want && here && want !== here) {
         // Mark pre-redirect to prevent any visual flash
         document.documentElement.setAttribute('data-pre-redirect','1');
         // Redirect immediately before anything renders

--- a/public/tally.html
+++ b/public/tally.html
@@ -180,10 +180,12 @@
 
     // One-time bypass set by buttons before navigating
     var launchOverride = (sessionStorage.getItem('launch_override') || '').toLowerCase();
+    var bootRedirected = sessionStorage.getItem('boot_router_redirect') === 'tally';
+    if (bootRedirected) sessionStorage.removeItem('boot_router_redirect');
     if (hasExplicitIntent || launchOverride === 'tally' || launchOverride === 'any') {
       // consume the one-time bypass so it doesn't affect later launches
       sessionStorage.removeItem('launch_override');
-    } else if (cold && want && here && want !== here) {
+    } else if (!bootRedirected && cold && want && here && want !== here) {
       // Mark pre-redirect to prevent any visual flash
       document.documentElement.setAttribute('data-pre-redirect','1');
       // Redirect immediately before anything renders


### PR DESCRIPTION
## Summary
- Mark redirects from boot-router with `sessionStorage.boot_router_redirect`
- Skip ultra-early auto-redirect when boot-router has already handled navigation

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b99485bddc832189a397f45c8d062e