### PR TITLE
refactor offline guard

### DIFF
--- a/public/boot-router.js
+++ b/public/boot-router.js
@@ -19,7 +19,6 @@
   }
 
   realOffline().then(off=>{
-    window.__REAL_OFFLINE__ = off;
     update();
     const role = (localStorage.getItem('user_role')||'').toLowerCase();
     if (role === 'contractor' && off && !/tally\.html$/i.test(location.pathname)){

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -237,10 +237,6 @@
       // Keep killing blockers briefly in case other code flips them back
       var n=0, t=setInterval(function(){ hideBlockers(); if (++n>12) clearInterval(t); }, 600);
       addFallbackLink();
-      // Expose a flag so dashboard.js can check it too
-      window.__REAL_OFFLINE__ = true;
-    } else {
-      window.__REAL_OFFLINE__ = false;
     }
   })();
 })();

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1741,9 +1741,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const overlay = document.getElementById('loading-overlay');
 
   // ---- OFFLINE GUARD: do not re-show overlay or start auth when offline
-  const _isReallyOffline = (typeof isReallyOffline === 'function')
-    ? isReallyOffline()
-    : (window.__REAL_OFFLINE__ === true || !navigator.onLine || localStorage.getItem('force_offline')==='1');
+  const _isReallyOffline = isReallyOffline();
 
   if (_isReallyOffline) {
     // Hide/remove any blocking overlay so taps work


### PR DESCRIPTION
## Summary
- simplify dashboard offline guard to rely on `isReallyOffline`
- drop legacy `window.__REAL_OFFLINE__` flag usage in boot router
- remove obsolete offline flag from dashboard HTML

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b99e84faf88321946f661dd5cd7664