### PR TITLE
chore: remove redundant offline scripts

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -170,77 +170,7 @@
     </style>
   </head>
 <body>
-  <script>
-(function(){
-  // ---- Robust offline detector ----
-  function timeout(ms){ return new Promise((_,rej)=>setTimeout(()=>rej(new Error('probe-timeout')), ms)); }
-  async function probeOnline() {
-    // Use a small, cacheable asset that should exist. Prefer '/manifest.json'; fallback to '/tally.html'
-    const url = '/manifest.json?probe=' + Date.now();
-    try {
-      const res = await Promise.race([
-        fetch(url, { method:'HEAD', cache:'no-store', mode:'no-cors' }),
-        timeout(1200)
-      ]);
-      // If fetch resolves, consider it online (even if opaque)
-      return true;
-    } catch (_) {
-      return false;
-    }
-  }
-
-  async function detectRealOffline() {
-    if (localStorage.getItem('force_offline') === '1') return true;
-    // don't trust navigator.onLine alone
-    const ok = await probeOnline();
-    return !ok;
-  }
-
-  function hideBlockers(){
-    [
-      '#loading-overlay','.loading-overlay','.boot-overlay','.boot-hiding',
-      '#dashboardOverlay','.modal-backdrop','.blocker','.page-mask'
-    ].forEach(function(sel){
-      document.querySelectorAll(sel).forEach(function(el){
-        el.style.display = 'none';
-        el.style.opacity = '0';
-        el.style.pointerEvents = 'none';
-        el.classList && el.classList.remove('boot-hiding');
-        el.removeAttribute && el.removeAttribute('aria-hidden');
-      });
-    });
-    var root = document.getElementById('app') || document.body;
-    root.style.pointerEvents = 'auto';
-    root.style.opacity = '1';
-  }
-
-  function addFallbackLink(){
-    if (document.getElementById('offlineTallyLink')) return;
-    var a=document.createElement('a');
-    a.id='offlineTallyLink';
-    a.href='/tally.html';
-    a.textContent='Open Tally (Offline)';
-    a.style.cssText='position:fixed;top:10px;right:10px;z-index:2147483647;background:rgba(0,0,0,.7);color:#fff;padding:6px 10px;border-radius:6px;font:13px system-ui;text-decoration:none';
-    a.addEventListener('click', function(e){ e.preventDefault(); e.stopPropagation(); location.href='/tally.html'; }, {passive:false});
-    document.body.appendChild(a);
-  }
-
-  // Run detection ASAP
-  (async function(){
-    var role = localStorage.getItem('user_role');
-    if (role !== 'contractor') return;
-
-    var reallyOffline = await detectRealOffline();
-    if (reallyOffline) {
-      document.body.classList.add('offline-mode');
-      hideBlockers();
-      // Keep killing blockers briefly in case other code flips them back
-      var n=0, t=setInterval(function(){ hideBlockers(); if (++n>12) clearInterval(t); }, 600);
-      addFallbackLink();
-    }
-  })();
-})();
-  </script>
+  
   <script>
     // Safety: if CSS hides the page at boot (e.g. .boot-hiding), unhide after 1200ms no matter what.
     setTimeout(() => { document.documentElement.classList.remove('boot-hiding'); }, 1200);
@@ -812,28 +742,5 @@
 </div>
   <script src="/pwa-suppress-install.js" defer></script>
   <script src="app-launch-guard.js" defer></script>
-  <script>
-    try {
-      localStorage.setItem('user_role', 'contractor');
-      localStorage.setItem('preferred_start', 'dashboard');
-    } catch(e) {}
-  </script>
-  <script>
-    (function(){
-      const role = (localStorage.getItem('user_role') || '').toLowerCase();
-      if (role === 'contractor' && !navigator.onLine) {
-        console.log('[offline-nav] Serving cached dashboard/tally pages');
-        const toast = document.createElement('div');
-        toast.textContent = 'Offline mode: cached pages active';
-        Object.assign(toast.style, {
-          position: 'fixed', bottom: '10px', left: '50%', transform: 'translateX(-50%)',
-          background: 'rgba(0,0,0,0.7)', color: '#fff', padding: '8px 12px',
-          borderRadius: '4px', zIndex: 1000
-        });
-        document.body.appendChild(toast);
-        setTimeout(() => toast.remove(), 3000);
-      }
-    })();
-  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove custom offline detection script from dashboard.html
- drop inline user_role/preferred_start and offline toast scripts
- rely on dashboard.js for offline navigation

## Testing
- `curl -I http://localhost:8000/public/dashboard.html`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b99f3651ec83219c3c34df0587c500