### PR TITLE
chore: remove old service worker init

### DIFF
--- a/public/serviceworker.js
+++ b/public/serviceworker.js
@@ -1,7 +1,0 @@
-if ('serviceWorker' in navigator) {
-  window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/service-worker.js') // ✅ leading slash
-      .then(reg => console.log('Service Worker registered:', reg.scope))
-      .catch(err => console.log('Service Worker registration failed:', err));
-  });
-}


### PR DESCRIPTION
## Summary
- remove legacy serviceworker.js file
- service worker registration now relies on sw-init.js referenced in HTML pages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9a0388e2083218bdff2f9852cf70c