### PR TITLE
Fix new day unlock logic and restrict PIN prompt to loaded sessions

### DIFF
--- a/public/tally.js
+++ b/public/tally.js
@@ -3006,9 +3006,14 @@ function resetForNewDay() {
     localStorage.removeItem('active_session');
     localStorage.removeItem('firestoreSessionId');
     localStorage.removeItem('viewOnlyMode');
+    localStorage.setItem('viewOnlyMode', 'false');
   } catch (e) {
     // Ignore any errors
   }
+
+  // Ensure new day starts unlocked
+  window.sessionLocked = false;
+  unlockSession();
 }
 
 function loadSessionObject(session) {
@@ -3277,8 +3282,8 @@ const interceptReset = (full) => (e) => {
         const inTally = t.matches('#tallySheetView input, #tallySheetView textarea, #tallySheetView select');
         if (!inTally) return;
 
-        // If already unlocked, do nothing
-        if (!window.sessionLocked) return;
+        // Only trigger PIN when session is locked AND a saved session was loaded
+        if (!(window.sessionLocked && window.isLoadedSession)) return;
 
         // Prevent typing/focus action while we decide
         e.preventDefault();


### PR DESCRIPTION
## Summary
- Reset view state on new day by clearing storage, setting `viewOnlyMode` to false, and unlocking the session
- Only trigger contractor PIN prompt when editing a locked, loaded session

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bcb8e6ca708321bc5b884cb08e5e80