### PR TITLE
Prevent unnecessary PIN prompts and unlock inputs fully

### DIFF
--- a/public/tally.js
+++ b/public/tally.js
@@ -864,6 +864,7 @@ function lockSession() {
 
 function unlockSession() {
   window.sessionLocked = false;
+  document.querySelectorAll('[data-locked="1"]').forEach(el => el.removeAttribute('data-locked'));
   const view = document.querySelector('#tallySheetView');
   if (view) removeLockFromContainer(view);
 }
@@ -3007,6 +3008,7 @@ function resetForNewDay() {
     localStorage.removeItem('firestoreSessionId');
     localStorage.removeItem('viewOnlyMode');
     localStorage.setItem('viewOnlyMode', 'false');
+    window.isLoadedSession = false; // Ensure fresh sessions are never mistaken as loaded
   } catch (e) {
     // Ignore any errors
   }


### PR DESCRIPTION
## Summary
- Reset `isLoadedSession` when starting a new day to prevent fresh sessions from prompting for a PIN.
- Fully clear leftover `data-locked` attributes when unlocking a session so all inputs become editable.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bccee963e883219c66c8c892cd7201