### PR TITLE
Rename Full Sheep table headers

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -204,7 +204,7 @@
                 <h3>Full Sheep (excludes crutched)</h3>
                 <table class="kpi-table" id="kpiFullSheepTable">
                   <thead>
-                    <tr><th>Sheep Type</th><th>Total</th><th>% of Full</th><th>Farms</th><th>Top Farm (day)</th></tr>
+                    <tr><th>Sheep Type Breakdown</th><th>Total</th><th>% of total</th><th>Farms</th><th>Top Farm (day)</th></tr>
                   </thead>
                   <tbody></tbody>
                 </table>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -2578,7 +2578,7 @@ console.info('[SHEAR iQ] To backfill savedAt on older sessions, run: backfillSav
 
   // CSV export (current tables)
   exportBtn?.addEventListener('click', () => {
-    const rows = [['Section','Sheep Type','Total','Percent','Farms','Top Farm (day)']];
+    const rows = [['Section','Sheep Type Breakdown','Total','% of total','Farms','Top Farm (day)']];
     document.querySelectorAll('#kpiFullSheepTable tbody tr').forEach(tr=>{
       const cells=[...tr.children].map(td=>td.textContent.trim());
       rows.push(['Full Sheep', ...cells]);


### PR DESCRIPTION
## Summary
- Rename Full Sheep table header to "Sheep Type Breakdown" and update column to "% of total"
- Sync CSV export headers with new names

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bcd2a431d48321957c222bfa3f27b8