### PR TITLE
Rename Full Sheep table title to Sheep Type Breakdown

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -201,10 +201,10 @@
 
             <div class="kpi-sections">
               <section>
-                <h3>Full Sheep (excludes crutched)</h3>
+                <h3>Sheep Type Breakdown</h3>
                 <table class="kpi-table" id="kpiFullSheepTable">
                   <thead>
-                    <tr><th>Sheep Type</th><th>Total</th><th>% of Full</th><th>Farms</th><th>Top Farm (day)</th></tr>
+                    <tr><th>Sheep Type</th><th>Total</th><th>% of total</th><th>Farms</th><th>Top Farm (day)</th></tr>
                   </thead>
                   <tbody></tbody>
                 </table>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -2578,7 +2578,7 @@ console.info('[SHEAR iQ] To backfill savedAt on older sessions, run: backfillSav
 
   // CSV export (current tables)
   exportBtn?.addEventListener('click', () => {
-    const rows = [['Section','Sheep Type','Total','Percent','Farms','Top Farm (day)']];
+    const rows = [['Section','Sheep Type','Total','% of total','Farms','Top Farm (day)']];
     document.querySelectorAll('#kpiFullSheepTable tbody tr').forEach(tr=>{
       const cells=[...tr.children].map(td=>td.textContent.trim());
       rows.push(['Full Sheep', ...cells]);


### PR DESCRIPTION
## Summary
- Set Full Sheep table title to "Sheep Type Breakdown" to clarify content
- Restore "Sheep Type" column header and keep "% of total" label
- Align CSV export headers with the on-screen table

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bcd2a431d48321957c222bfa3f27b8