### PR TITLE
Mark loaded sessions for PIN prompt

### DIFF
--- a/public/tally.js
+++ b/public/tally.js
@@ -3019,6 +3019,9 @@ function resetForNewDay() {
 }
 
 function loadSessionObject(session) {
+    // Mark that a previously saved session is now active
+    window.isLoadedSession = true;
+
     // Cancel any pending autosave to avoid unintended saves while loading
     if (autosaveTimer) {
         clearTimeout(autosaveTimer);


### PR DESCRIPTION
## Summary
- Set `window.isLoadedSession = true` whenever `loadSessionObject` runs to ensure saved sessions are recognized

## Testing
- `npm test` *(fails: Missing script: "test")*
- Verified focus handler triggers `promptForPinUnlock` when session is loaded and locked


------
https://chatgpt.com/codex/tasks/task_e_68bcd2a7a66883219ce883e2caf21cd2