### PR TITLE
Rename total crew hours label in KPI summary

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -307,7 +307,7 @@
                 </table>
                 <small class="kpi-note">
                   <strong>Session Hours</strong> = actual shed operating time per session.<br>
-                  <strong>Total Crew Hours</strong> = combined individual hours for all people in a session.<br>
+                  <strong>Total Hours Worked By All Staff (combined)</strong> = combined individual hours for all people in a session.<br>
                   <strong>Shed Staff Hours</strong> = combined individual hours for shed staff only.
                 </small>
               </section>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -3183,7 +3183,7 @@ const rows = [['Section','Sheep Type','Total','% of total','Farms','Top Farm (da
   function renderSummary(sessionHours, crewHours, shedStaffHours){
     tbodySummary.innerHTML = `
       <tr><td>Session Hours (pill metric)</td><td>${hoursToHM(sessionHours)}</td></tr>
-      <tr><td>Total Crew Hours</td><td>${hoursToHM(crewHours)}</td></tr>
+      <tr><td>Total Hours Worked By All Staff (combined)</td><td>${hoursToHM(crewHours)}</td></tr>
       <tr><td>Shed Staff Hours (combined)</td><td>${hoursToHM(shedStaffHours)}</td></tr>
     `;
   }


### PR DESCRIPTION
## Summary
- rename "Total Crew Hours" header to "Total Hours Worked By All Staff (combined)" in total hours KPI summary and note

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bcdb7972c48321a2bc7a30b9ff0b4c