### PR TITLE
Fix station totals table header clearing

### DIFF
--- a/public/tally.js
+++ b/public/tally.js
@@ -2550,7 +2550,7 @@ function clearStationSummaryView() {
     document.querySelector('#stationStaffTable tbody')?.replaceChildren();
     document.querySelector('#stationLeaderTable tbody')?.replaceChildren();
     document.querySelector('#stationCombTable tbody')?.replaceChildren();
-    document.querySelector('#stationTotalTable thead')?.replaceChildren();
+    document.querySelector('#stationTotalTable thead tr')?.replaceChildren();
     document.querySelector('#stationTotalTable tbody')?.replaceChildren();
     const msg = document.getElementById('stationNoData');
     if (msg) msg.style.display = 'block';


### PR DESCRIPTION
## Summary
- Ensure `clearStationSummaryView` removes header row contents from totals table

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bce59e91288321804efd056feca60e