### PR TITLE
Fix station totals table header and rename totals heading

### DIFF
--- a/public/export.js
+++ b/public/export.js
@@ -30,7 +30,7 @@ function exportFarmSummaryCSV() {
         ['stationStaffTable', 'Shed Staff'],
         ['stationLeaderTable', 'Team Leaders'],
         ['stationCombTable', 'Comb Types'],
-        ['stationTotalTable', 'Totals']
+        ['stationTotalTable', 'Sheep Type Total']
     ];
 
     const rows = [];

--- a/public/tally.html
+++ b/public/tally.html
@@ -460,7 +460,7 @@
     <thead><tr><th>Comb Type</th><th>Dates Used</th></tr></thead>
     <tbody></tbody>
   </table>
-  <h3>Totals</h3>
+  <h3>Sheep Type Total</h3>
   <table id="stationTotalTable" data-help="Overall totals for the farm.">
     <thead><tr></tr></thead>
     <tbody></tbody>

--- a/public/tally.js
+++ b/public/tally.js
@@ -2550,7 +2550,7 @@ function clearStationSummaryView() {
     document.querySelector('#stationStaffTable tbody')?.replaceChildren();
     document.querySelector('#stationLeaderTable tbody')?.replaceChildren();
     document.querySelector('#stationCombTable tbody')?.replaceChildren();
-    document.querySelector('#stationTotalTable thead')?.replaceChildren();
+    document.querySelector('#stationTotalTable thead tr')?.replaceChildren();
     document.querySelector('#stationTotalTable tbody')?.replaceChildren();
     const msg = document.getElementById('stationNoData');
     if (msg) msg.style.display = 'block';


### PR DESCRIPTION
## Summary
- Ensure `clearStationSummaryView` removes header row contents from totals table
- Rename totals table heading to "Sheep Type Total" and update CSV export

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bce59e91288321804efd056feca60e