### PR TITLE
Hide time labels on dashboard calendar

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -3544,6 +3544,7 @@ const rows = [['Section','Sheep Type','Total','% of total','Farms','Top Farm (da
         initialView: defaultView,
         headerToolbar: { left: 'prev,next today', center: 'title', right: 'dayGridMonth,timeGridWeek,timeGridDay' },
         events,
+        displayEventTime: false,
         eventClick: info => {
           info.jsEvent.preventDefault();
           const id = info.event.id;


### PR DESCRIPTION
## Summary
- stop FullCalendar from showing event times on the dashboard so entries no longer show "12a"

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bd1dc7b7a88321815e6f118cacca54