### PR TITLE
Ensure dashboard calendar is horizontally scrollable

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -142,9 +142,14 @@
       width: 90%;
       max-width: 1000px;
       height: 90%;
-      overflow: auto;
+      overflow-x: auto;
+      overflow-y: auto;
       border-radius: 8px;
       border: 1px solid var(--border-color, #2c2c2c);
+    }
+
+    #calendarOverlay #calendar {
+      min-width: 700px;
     }
     #calendarClose {
       float: right;
@@ -711,7 +716,7 @@
         </div>
       </div>
     </div>
-  <div id="calendarOverlay" class="calendar-overlay" hidden>
+  <div id="calendarOverlay" class="calendar-overlay">
     <div class="calendar-content">
       <button id="calendarClose" aria-label="Close">&times;</button>
       <select id="calendarFarmFilter"></select>


### PR DESCRIPTION
## Summary
- Allow horizontal and vertical scrolling in dashboard calendar overlay
- Preserve a minimum calendar width so all days remain accessible on small screens
- Remove hidden attribute from calendar overlay markup so it can display when activated

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bd2163a78c8321ae0fb5248d05e9a1