### PR TITLE
feat: add calendar diagnostics

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -37,8 +37,10 @@
   <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
   <script src="firebase-init.js"></script>
   <script type="module" src="auth.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.css">
-  <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
+    <!-- <script src="/fullcalendar/index.global.min.js"></script> -->
+    <script>if(!window.FullCalendar){console.warn('FullCalendar failed to load. Consider hosting a local copy or alternate CDN.');}</script>
   <!-- PWA manifest -->
   <link rel="manifest" href="/manifest.json">
 


### PR DESCRIPTION
## Summary
- log calendar diagnostics behind `?diag=1`
- warn if FullCalendar or contractor ID is missing
- add optional local FullCalendar fallback

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bd331882d483219b9581ae4e46117f