### PR TITLE
Ensure calendar modal toggles hidden attribute

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -3670,11 +3670,20 @@ window.addEventListener('resize', () => {
 
   btn.addEventListener('click', () => {
     modal.classList.add('active');
+    modal.hidden = false;
     renderCalendar();
     requestAnimationFrame(renderCalendarIfNeeded);
   });
-  closeBtn.addEventListener('click', () => modal.classList.remove('active'));
-  modal.addEventListener('click', e => { if (e.target === modal) modal.classList.remove('active'); });
+  closeBtn.addEventListener('click', () => {
+    modal.classList.remove('active');
+    modal.hidden = true;
+  });
+  modal.addEventListener('click', e => {
+    if (e.target === modal) {
+      modal.classList.remove('active');
+      modal.hidden = true;
+    }
+  });
   if (modal) {
     modal.addEventListener('transitionend', e => {
       if (e.target === modal && modal.classList.contains('active')) {


### PR DESCRIPTION
## Summary
- Unhide calendar modal on open by clearing `hidden`
- Re-hide calendar modal when closed via button or overlay click

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bd3f3328948321a98a04fabfd5e9d1