### PR TITLE
Fix calendar not showing in iOS portrait

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -3668,11 +3668,14 @@ window.addEventListener('resize', () => {
     renderCalendarIfNeeded();
   }
 
-  btn.addEventListener('click', () => {
+  btn.addEventListener('click', async () => {
     modal.classList.add('active');
     modal.hidden = false;
-    renderCalendar();
-    requestAnimationFrame(renderCalendarIfNeeded);
+    await renderCalendar();
+    requestAnimationFrame(() => {
+      renderCalendarIfNeeded();
+      forceCalendarResize();
+    });
   });
   closeBtn.addEventListener('click', () => {
     modal.classList.remove('active');
@@ -3688,9 +3691,13 @@ window.addEventListener('resize', () => {
     modal.addEventListener('transitionend', e => {
       if (e.target === modal && modal.classList.contains('active')) {
         renderCalendarIfNeeded();
+        forceCalendarResize();
       }
     });
-    modal.addEventListener('modal:shown', renderCalendarIfNeeded);
+    modal.addEventListener('modal:shown', () => {
+      renderCalendarIfNeeded();
+      forceCalendarResize();
+    });
   }
   farmSel.addEventListener('change', renderCalendar);
 


### PR DESCRIPTION
## Summary
- trigger FullCalendar to resize after opening the calendar modal
- ensure iOS devices render calendar data in portrait orientation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68bd413d709483219a5b08f9021eab15