### PR TITLE
Fix calendar not showing in portrait orientation

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -3505,6 +3505,7 @@ function safeInitialRender() {
     return;
   }
   renderCalendarIfNeeded();
+  forceCalendarResize();
 }
 
 window.addEventListener('orientationchange', () => {


### PR DESCRIPTION
## Summary
- ensure calendar resizes after initial render so events appear on iOS portrait

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bd43006dc08321b7429280a9add5c0