### PR TITLE
Fix calendar rendering on iOS in portrait

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -3509,11 +3509,17 @@ function safeInitialRender() {
 }
 
 window.addEventListener('orientationchange', () => {
-  setTimeout(forceCalendarResize, 200);
+  setTimeout(() => {
+    renderCalendarIfNeeded();
+    forceCalendarResize();
+  }, 200);
 });
 
 window.addEventListener('resize', () => {
-  setTimeout(forceCalendarResize, 150);
+  setTimeout(() => {
+    renderCalendarIfNeeded();
+    forceCalendarResize();
+  }, 150);
 });
 
 // === Calendar View ===

--- a/public/styles.css
+++ b/public/styles.css
@@ -1467,9 +1467,11 @@ button {
 /* Ensure the calendar has space to render in iOS Safari */
 #calendar, .calendar-container {
   min-height: 60vh;
+  height: 100%;
 }
 @supports (-webkit-touch-callout: none) {
   #calendar, .calendar-container {
     min-height: 60vh;
+    height: 60vh;
   }
 }


### PR DESCRIPTION
## Summary
- ensure calendar container has explicit height so FullCalendar renders on iOS
- re-render and resize calendar when orientation or window size changes

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bd44a05e4c8321a1355cc6c02c54c8