### PR TITLE
Fix iOS portrait calendar rendering

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -3508,19 +3508,18 @@ function safeInitialRender() {
   forceCalendarResize();
 }
 
-window.addEventListener('orientationchange', () => {
+function scheduleCalendarResize(delay = 150) {
   setTimeout(() => {
     renderCalendarIfNeeded();
     forceCalendarResize();
-  }, 200);
-});
+  }, delay);
+}
 
-window.addEventListener('resize', () => {
-  setTimeout(() => {
-    renderCalendarIfNeeded();
-    forceCalendarResize();
-  }, 150);
-});
+window.addEventListener('orientationchange', () => scheduleCalendarResize(200));
+window.addEventListener('resize', () => scheduleCalendarResize(150));
+if (window.visualViewport) {
+  window.visualViewport.addEventListener('resize', () => scheduleCalendarResize(150));
+}
 
 // === Calendar View ===
 
@@ -3679,10 +3678,9 @@ window.addEventListener('resize', () => {
     modal.classList.add('active');
     modal.hidden = false;
     await renderCalendar();
-    requestAnimationFrame(() => {
-      renderCalendarIfNeeded();
-      forceCalendarResize();
-    });
+    scheduleCalendarResize(0);
+    requestAnimationFrame(() => scheduleCalendarResize(0));
+    setTimeout(() => scheduleCalendarResize(0), 300);
   });
   closeBtn.addEventListener('click', () => {
     modal.classList.remove('active');

--- a/public/styles.css
+++ b/public/styles.css
@@ -1475,3 +1475,14 @@ button {
     height: 60vh;
   }
 }
+
+/* Ensure calendar fills available space within modal */
+#calendarModal .calendar-content {
+  display: flex;
+  flex-direction: column;
+}
+
+#calendarModal .calendar-content #calendar,
+#calendarModal .calendar-content .calendar-container {
+  flex: 1 1 auto;
+}


### PR DESCRIPTION
## Summary
- make calendar modal a flex container so the calendar div grows to fill space
- add resilient calendar resize helper and hook into visualViewport changes and modal open

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bd464f572083218f33148d1ecb4491