### PR TITLE
fix: ensure calendar renders in portrait modal on iOS

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -3678,6 +3678,12 @@ if (window.visualViewport) {
     modal.classList.add('active');
     modal.hidden = false;
     await renderCalendar();
+    // Ensure FullCalendar recalculates dimensions after the modal becomes visible
+    setTimeout(() => {
+      try {
+        window.dashboardCalendar?.updateSize();
+      } catch (e) {}
+    }, 100);
     scheduleCalendarResize(0);
     requestAnimationFrame(() => scheduleCalendarResize(0));
     setTimeout(() => scheduleCalendarResize(0), 300);

--- a/public/styles.css
+++ b/public/styles.css
@@ -1466,11 +1466,14 @@ button {
 
 /* Ensure the calendar has space to render in iOS Safari */
 #calendar, .calendar-container {
+  /* Fallback ensures a non-zero height when the modal is initially hidden */
+  min-height: 300px;
   min-height: 60vh;
   height: 100%;
 }
 @supports (-webkit-touch-callout: none) {
   #calendar, .calendar-container {
+    min-height: 300px;
     min-height: 60vh;
     height: 60vh;
   }


### PR DESCRIPTION
## Summary
- ensure FullCalendar recalculates size after modal becomes visible
- add CSS fallback so calendar has minimum height when hidden

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bd485739e0832198b82f74ec11f12a