### PR TITLE
Ensure FullCalendar recalculates width on iOS modal open

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -3484,6 +3484,7 @@ function forceCalendarResize() {
   requestAnimationFrame(() => {
     try {
       cal.updateSize();
+      cal.render();
     } catch (e) {}
   });
 }
@@ -3681,7 +3682,9 @@ if (window.visualViewport) {
     // Ensure FullCalendar recalculates dimensions after the modal becomes visible
     setTimeout(() => {
       try {
-        window.dashboardCalendar?.updateSize();
+        const cal = window.dashboardCalendar;
+        cal?.updateSize();
+        cal?.render();
       } catch (e) {}
     }, 100);
     scheduleCalendarResize(0);

--- a/public/styles.css
+++ b/public/styles.css
@@ -1470,12 +1470,16 @@ button {
   min-height: 300px;
   min-height: 60vh;
   height: 100%;
+  width: 100vw;
+  width: 100%;
 }
 @supports (-webkit-touch-callout: none) {
   #calendar, .calendar-container {
     min-height: 300px;
     min-height: 60vh;
     height: 60vh;
+    width: 100vw;
+    width: 100%;
   }
 }
 
@@ -1488,4 +1492,6 @@ button {
 #calendarModal .calendar-content #calendar,
 #calendarModal .calendar-content .calendar-container {
   flex: 1 1 auto;
+  width: 100vw;
+  width: 100%;
 }


### PR DESCRIPTION
## Summary
- Guarantee calendar container spans full width across orientations with explicit width settings and fallbacks.
- Trigger FullCalendar to update and re-render after the modal becomes visible, ensuring immediate event display on iOS.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bd4c532ef48321919ceada44f10eaa