### PR TITLE
fix: ensure calendar renders in iOS

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -3675,22 +3675,21 @@ if (window.visualViewport) {
     renderCalendarIfNeeded();
   }
 
-  btn.addEventListener('click', async () => {
+  // After modal opens, force calendar to resize
+  async function showCalendarModal() {
     modal.classList.add('active');
     modal.hidden = false;
     await renderCalendar();
-    // Ensure FullCalendar recalculates dimensions after the modal becomes visible
-    setTimeout(() => {
-      try {
-        const cal = window.dashboardCalendar;
-        cal?.updateSize();
-        cal?.render();
-      } catch (e) {}
-    }, 100);
-    scheduleCalendarResize(0);
-    requestAnimationFrame(() => scheduleCalendarResize(0));
-    setTimeout(() => scheduleCalendarResize(0), 300);
-  });
+
+    // now fix the calendar
+    if (window.dashboardCalendar) {
+      setTimeout(() => {
+        window.dashboardCalendar.updateSize();
+      }, 100);
+    }
+  }
+
+  btn.addEventListener('click', showCalendarModal);
   closeBtn.addEventListener('click', () => {
     modal.classList.remove('active');
     modal.hidden = true;

--- a/public/styles.css
+++ b/public/styles.css
@@ -1464,23 +1464,10 @@ button {
   fill:currentColor;
 }
 
-/* Ensure the calendar has space to render in iOS Safari */
-#calendar, .calendar-container {
-  /* Fallback ensures a non-zero height when the modal is initially hidden */
-  min-height: 300px;
-  min-height: 60vh;
-  height: 100%;
-  width: 100vw;
+/* Ensure the calendar always has height so FullCalendar renders */
+#calendar {
   width: 100%;
-}
-@supports (-webkit-touch-callout: none) {
-  #calendar, .calendar-container {
-    min-height: 300px;
-    min-height: 60vh;
-    height: 60vh;
-    width: 100vw;
-    width: 100%;
-  }
+  min-height: 360px;   /* always give it height */
 }
 
 /* Ensure calendar fills available space within modal */


### PR DESCRIPTION
## Summary
- ensure calendar container has a fixed minimum height so FullCalendar can render
- resize FullCalendar after the modal is shown

## Testing
- `npm test` *(fails: Missing script "test"*)

------
https://chatgpt.com/codex/tasks/task_e_68bd746cbf948321a93ffcf71a8e6ddd