### PR TITLE
fix: ensure calendar renders within modal

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1509,3 +1509,25 @@ button {
 #btnCalendar.cal-ready {
   color: #33d17a !important; /* green */
 }
+
+/* Ensure modal content has height in portrait */
+.calendar-modal .modal-content,
+.calendar-modal .modal-body {
+  min-height: 360px;
+}
+
+/* Calendar box must always have width/height */
+#calendar {
+  width: 100%;
+  min-height: 360px;
+  height: auto; /* JS will set exact pixel height */
+}
+
+/* FullCalendar inner wrappers should expand fully */
+#calendar .fc,
+#calendar .fc-view-harness,
+#calendar .fc-scrollgrid,
+#calendar .fc-scroller-harness,
+#calendar .fc-scroller {
+  height: 100% !important;
+}


### PR DESCRIPTION
## Summary
- guarantee calendar modal has minimum height and internal wrappers stretch
- measure modal body and render FullCalendar only after visible

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bd81f8507c8321abf4bd027ba546af