### PR TITLE
chore: remove unused calendar ready styling

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -3675,13 +3675,6 @@ if (window.visualViewport) {
     renderCalendarIfNeeded();
   }
 
-  // Mark the calendar button green permanently
-  function markCalendarReady() {
-    const btnReady = document.getElementById('btnCalendar');
-    if (!btnReady) return;
-    btnReady.classList.add('cal-ready');
-  }
-
   // Ensure this runs after modal is visible
   async function showCalendarModal() {
     modal.classList.add('active');

--- a/public/styles.css
+++ b/public/styles.css
@@ -1505,11 +1505,6 @@ button {
   height: 100% !important;
 }
 
-/* Permanent green font for calendar button once calendar is ready */
-#btnCalendar.cal-ready {
-  color: #33d17a !important; /* green */
-}
-
 /* Ensure modal content has height in portrait */
 .calendar-modal .modal-content,
 .calendar-modal .modal-body {


### PR DESCRIPTION
## Summary
- remove unused calendar-ready function
- drop unused calendar button style

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bd8884fdd483219ec422b275bc1b54