### PR TITLE
feat: honour staff load session permission

### DIFF
--- a/public/view-sessions.js
+++ b/public/view-sessions.js
@@ -1,6 +1,8 @@
 // view-sessions.js
 // Loads and displays sessions for the logged-in contractor.
 
+const K_STAFF_CAN_LOAD = 'dashboard_staff_can_load';
+
 function formatNZDate(iso) {
   if (!iso) return '';
   const d = new Date(iso);
@@ -290,6 +292,12 @@ async function loadNextPage() {
 // Main entry
 
 document.addEventListener('DOMContentLoaded', () => {
+  const canLoad = localStorage.getItem(K_STAFF_CAN_LOAD) !== 'false';
+  const role = sessionStorage.getItem('userRole');
+  if (role === 'staff' && !canLoad) {
+    window.location.replace('tally.html');
+    return;
+  }
   const overlay = document.getElementById('loading-overlay');
   if (overlay) overlay.style.display = 'flex';
 


### PR DESCRIPTION
## Summary
- read `staffCanLoadSessions` flag on tally startup and hide Load Session UI for staff without permission
- guard load session modals and view sessions page based on staff load permission

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bd8cb9a7248321967402c20a600d99