### PR TITLE
Allow certain roles to load cloud sessions

### DIFF
--- a/public/tally.js
+++ b/public/tally.js
@@ -2695,15 +2695,23 @@ function buildExportRows(data) {
 }
 
 function updateUIForRole(role) {
-    const admin = role === 'admin';
-    const ids = ['saveCloudBtn', 'saveBothBtn', 'loadCloudBtn'];
-    ids.forEach(id => {
+    const adminIds = ['saveCloudBtn', 'saveBothBtn'];
+    adminIds.forEach(id => {
         const el = document.getElementById(id);
-        if (el) {
-            if (admin) el.removeAttribute('disabled');
-            else el.setAttribute('disabled', 'disabled');
-        }
+        if (!el) return;
+        if (role === 'admin') el.removeAttribute('disabled');
+        else el.setAttribute('disabled', 'disabled');
     });
+
+    const loadCloudBtn = document.getElementById('loadCloudBtn');
+    if (loadCloudBtn) {
+        const canLoad =
+            role === 'admin' ||
+            role === 'contractor' ||
+            (role === 'staff' && window.staffCanLoadSessions);
+        if (canLoad) loadCloudBtn.removeAttribute('disabled');
+        else loadCloudBtn.setAttribute('disabled', 'disabled');
+    }
     const loadBtn = document.getElementById('loadSessionBtn');
     if (loadBtn) {
         if (role === 'staff' && window.staffCanLoadSessions === false) {

--- a/public/tally.js
+++ b/public/tally.js
@@ -2706,21 +2706,19 @@ function updateUIForRole(role) {
     const loadCloudBtn = document.getElementById('loadCloudBtn');
     if (loadCloudBtn) {
         const canLoad =
-            role === 'admin' ||
             role === 'contractor' ||
             (role === 'staff' && window.staffCanLoadSessions);
-        if (canLoad) loadCloudBtn.removeAttribute('disabled');
-        else loadCloudBtn.setAttribute('disabled', 'disabled');
+        loadCloudBtn.disabled = !canLoad;
     }
     const loadBtn = document.getElementById('loadSessionBtn');
     if (loadBtn) {
-        if (role === 'staff' && window.staffCanLoadSessions === false) {
+        if (role === 'staff' && !window.staffCanLoadSessions) {
             loadBtn.style.display = 'none';
         } else {
             loadBtn.style.display = '';
         }
     }
-    if (role === 'staff' && window.staffCanLoadSessions === false) {
+    if (role === 'staff' && !window.staffCanLoadSessions) {
         ['loadSessionModal', 'loadOptionsModal', 'cloudSessionModal'].forEach(id => {
             const el = document.getElementById(id);
             if (el) el.style.display = 'none';


### PR DESCRIPTION
## Summary
- Enable `loadCloudBtn` for contractors and staff with cloud load permissions
- Keep cloud save buttons admin-only

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bd9972de8c8321ab6743ea4f8784a1