### PR TITLE
fix(calendar-modal): rely on [hidden] for visibility; ensure pixel height before render; remove .active dependency

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -132,18 +132,12 @@
       right: 0;
       bottom: 0;
       background: rgba(0,0,0,0.8);
-      display: none;
       z-index: 1000;
     }
-    #calendarModal.active { display: block; }
     #calendarModal .calendar-content {
       background: var(--panel-bg, #0f1115);
       color: var(--text-color, #fff);
-      margin: 5% auto;
       padding: 10px;
-      width: 90%;
-      max-width: 1000px;
-      height: 90%;
       overflow: auto;
       border-radius: 8px;
       border: 1px solid var(--border-color, #2c2c2c);

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -3574,7 +3574,6 @@ if (window.visualViewport) {
     b.textContent = msg;
   }
 
-  const btn = document.getElementById('btnCalendar');
   const closeBtn = document.getElementById('calendarClose');
   const farmSel = document.getElementById('calendarFarmFilter');
   const fcScript = Array.from(document.getElementsByTagName('script')).find(s => /fullcalendar/i.test(s.src));
@@ -3583,7 +3582,7 @@ if (window.visualViewport) {
     console.log('[CAL] window.FullCalendar present?', !!window.FullCalendar, window.FullCalendar && window.FullCalendar.version);
     console.log('[CAL] FullCalendar script tag present?', !!fcScript, fcScript && fcScript.src);
   }
-  if (!btn || !document.getElementById('calendarModal') || !closeBtn || !farmSel || !document.getElementById('calendar') || !window.FullCalendar){
+  if (!document.getElementById('btnCalendar') || !document.getElementById('calendarModal') || !closeBtn || !farmSel || !document.getElementById('calendar') || !window.FullCalendar){
     if (diag && !window.FullCalendar) showDiagBanner('FullCalendar failed to load (check CDN/content blocker).');
     return;
   }
@@ -3698,13 +3697,13 @@ function setCalHeight() {
 }
 
 function openCalendarModal() {
-  // 1) Show modal first so it can be measured
+  // show modal (CSS now relies on [hidden])
   modal.hidden = false;
 
-  // 2) Give the calendar a real pixel height BEFORE render
+  // give calendar a real pixel height BEFORE render
   setCalHeight();
 
-  // 3) Render on the next frame (after height applies)
+  // render on next frame so height is applied
   requestAnimationFrame(() => {
     if (!window._fcCalendar) {
       window._fcCalendar = new FullCalendar.Calendar(calendarEl, calendarOptions);
@@ -3712,7 +3711,6 @@ function openCalendarModal() {
     window._fcCalendar.render();
     window._fcCalendar.updateSize();
 
-    // 4) Keep sizing correct during orientation/resize while modal is open
     if (!window._onCalResize) {
       window._onCalResize = () => {
         setCalHeight();
@@ -3723,8 +3721,8 @@ function openCalendarModal() {
   });
 }
 
-// Call openCalendarModal() from your Calendar button click handler
-// e.g. document.getElementById('openCalendarBtn').addEventListener('click', openCalendarModal);
+// hook up the button
+document.getElementById('btnCalendar')?.addEventListener('click', openCalendarModal);
 
 // When closing the modal, remove the resize listener (good hygiene)
 function closeCalendarModal() {
@@ -3738,8 +3736,7 @@ function closeCalendarModal() {
 }
 /// --- END calendar open logic ---
 
-  btn.addEventListener('click', openCalendarModal);
-  closeBtn.addEventListener('click', closeCalendarModal);
+  closeBtn?.addEventListener('click', closeCalendarModal);
   modal.addEventListener('click', e => { if (e.target === modal) closeCalendarModal(); });
   farmSel.addEventListener('change', () => { window._fcCalendar && window._fcCalendar.refetchEvents(); });
 })();

--- a/public/styles.css
+++ b/public/styles.css
@@ -1470,31 +1470,6 @@ button {
   fill:currentColor;
 }
 
-/* Ensure calendar fills available space within modal */
-.calendar-content {
-  display: flex;
-  flex-direction: column;
-}
-
-#calendar {
-  flex: 1;              /* expand to fill available space */
-  min-height: 70vh;     /* guarantee enough height on portrait */
-}
-
-#calendarModal .calendar-content #calendar,
-#calendarModal .calendar-content .calendar-container {
-  flex: 1 1 auto;
-  width: 100vw;
-  width: 100%;
-}
-/* Give the modal a real height in portrait */
-.calendar-modal .modal-content,
-.calendar-modal .modal-body {
-  height: 70svh;      /* iOS safe viewport */
-  min-height: 360px;  /* fallback */
-}
-
-/* Ensure FullCalendar inner wrappers don't collapse */
 #calendar .fc,
 #calendar .fc-view-harness,
 #calendar .fc-scrollgrid,
@@ -1503,30 +1478,11 @@ button {
   height: 100% !important;
 }
 
-@media (orientation: portrait) {
-  #calendar {
-    min-height: 70vh; /* give it real space on phones */
-  }
-}
+/* Visibility control for the calendar modal */
+#calendarModal { display: flex; align-items: center; justify-content: center; }
+#calendarModal[hidden] { display: none !important; }
 
-/* ---- Calendar modal height chain + stable viewport height ---- */
+/* Keep the height chain + layout */
 html, body { height: 100%; }
-#calendarModal {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 100%;
-}
-#calendarModal .calendar-content {
-  display: flex;
-  flex-direction: column;
-  /* use stable viewport units so iOS toolbars don’t collapse height */
-  height: 88svh;
-  width: 92vw;
-  max-width: 720px;
-}
-#calendar {
-  flex: 1;
-  height: 100%;
-  min-height: 0; /* important inside flex containers */
-}
+#calendarModal .calendar-content { display: flex; flex-direction: column; height: 88svh; width: 92vw; max-width: 720px; }
+#calendar { flex: 1; height: 100%; min-height: 0; }


### PR DESCRIPTION
## Summary
- switch calendar modal to use `hidden` attribute and flex-centric layout
- render FullCalendar after assigning real height to avoid collapse
- drop obsolete `.active`/`display:none` rules so modal opens reliably

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bd9d5eb8a8832185ac6df04511e2a3