### PR TITLE
Clean calendar modal code and CSS

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -124,57 +124,6 @@
       visibility: hidden !important;
     }
     </style>
-  <style>
-    #calendarModal {
-      position: fixed;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      background: rgba(0,0,0,0.8);
-      z-index: 1000;
-    }
-    #calendarModal .calendar-content {
-      background: var(--panel-bg, #0f1115);
-      color: var(--text-color, #fff);
-      padding: 10px;
-      overflow: auto;
-      border-radius: 8px;
-      border: 1px solid var(--border-color, #2c2c2c);
-    }
-    #calendarClose {
-      float: right;
-      background: transparent;
-      border: none;
-      color: inherit;
-      font-size: 24px;
-      cursor: pointer;
-    }
-    #calendarFarmFilter {
-      margin-bottom: 8px;
-      background: var(--panel-bg, #0f1115);
-      color: var(--text-color, #fff);
-      border: 1px solid var(--border-color, #2c2c2c);
-      padding: 4px;
-    }
-    #calendarModal .fc {
-      --fc-page-bg-color: var(--panel-bg, #0f1115);
-      --fc-border-color: var(--border-color, #2c2c2c);
-      --fc-neutral-bg-color: #1a1d24;
-      --fc-neutral-text-color: #b9c2d0;
-      --fc-text-color: var(--text-color, #fff);
-      --fc-button-bg-color: #444;
-      --fc-button-border-color: #444;
-      --fc-button-text-color: #fff;
-      --fc-button-hover-bg-color: #555;
-      --fc-button-hover-border-color: #555;
-      --fc-button-active-bg-color: #666;
-      --fc-button-active-border-color: #666;
-      --fc-today-bg-color: #1f2937;
-      --fc-event-bg-color: #3b82f6;
-      --fc-event-border-color: #3b82f6;
-    }
-  </style>
   </head>
 <body>
   
@@ -711,7 +660,7 @@
         </div>
       </div>
     </div>
-  <div id="calendarModal" class="calendar-overlay" hidden>
+  <div id="calendarModal" hidden>
     <div class="calendar-content">
       <button id="calendarClose" aria-label="Close">&times;</button>
       <select id="calendarFarmFilter"></select>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -3505,50 +3505,6 @@ SessionStore.onChange(refresh);
   if (SessionStore.getAll().length) refresh();
 })();
 
-function forceCalendarResize() {
-  const cal = window.dashboardCalendar;
-  if (!cal) return;
-  requestAnimationFrame(() => {
-    try {
-      cal.updateSize();
-      cal.render();
-    } catch (e) {}
-  });
-}
-
-function renderCalendarIfNeeded() {
-  const cal = window.dashboardCalendar;
-  if (!cal) return;
-  try {
-    cal.render();
-    cal.updateSize();
-  } catch (e) {}
-}
-
-function safeInitialRender() {
-  const el = document.getElementById('calendar');
-  if (!el) return;
-  if (el.clientWidth === 0 || el.clientHeight === 0) {
-    setTimeout(safeInitialRender, 200);
-    return;
-  }
-  renderCalendarIfNeeded();
-  forceCalendarResize();
-}
-
-function scheduleCalendarResize(delay = 150) {
-  setTimeout(() => {
-    renderCalendarIfNeeded();
-    forceCalendarResize();
-  }, delay);
-}
-
-window.addEventListener('orientationchange', () => scheduleCalendarResize(200));
-window.addEventListener('resize', () => scheduleCalendarResize(150));
-if (window.visualViewport) {
-  window.visualViewport.addEventListener('resize', () => scheduleCalendarResize(150));
-}
-
 // === Calendar View ===
 
 (function setupDashboardCalendar(){
@@ -3657,6 +3613,7 @@ if (window.visualViewport) {
   const calendarOptions = {
     initialView: localStorage.getItem('dashboard_calendar_view') || 'dayGridMonth',
     headerToolbar: { left: 'prev,next today', center: 'title', right: 'dayGridMonth,timeGridWeek,timeGridDay' },
+    height: '100%',
     events: async (info, successCallback, failureCallback) => {
       try {
         const sessions = await fetchSessions();

--- a/public/styles.css
+++ b/public/styles.css
@@ -1479,7 +1479,18 @@ button {
 }
 
 /* Visibility control for the calendar modal */
-#calendarModal { display: flex; align-items: center; justify-content: center; }
+#calendarModal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.8);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
 #calendarModal[hidden] { display: none !important; }
 
 /* Keep the height chain + layout */


### PR DESCRIPTION
## Summary
- drop legacy calendar functions and rely on new openCalendarModal flow
- centralize calendar modal styling in styles.css and remove inline HTML CSS
- ensure FullCalendar stretches to modal with `height: '100%'`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bda1aa2d208321b55fe689b327d6bd