### PR TITLE
Fix FullCalendar zero-height rendering on iPhone

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -3613,7 +3613,6 @@ SessionStore.onChange(refresh);
   const calendarOptions = {
     initialView: localStorage.getItem('dashboard_calendar_view') || 'dayGridMonth',
     headerToolbar: { left: 'prev,next today', center: 'title', right: 'dayGridMonth,timeGridWeek,timeGridDay' },
-    height: '100%',
     events: async (info, successCallback, failureCallback) => {
       try {
         const sessions = await fetchSessions();
@@ -3661,10 +3660,9 @@ SessionStore.onChange(refresh);
   function openCalendarModal() {
     document.body.classList.add('modal-open');
     modal.hidden = false;                  // [hidden] → visible
-
-    const px = applyCalHeight();           // set height BEFORE render
-
     requestAnimationFrame(() => {
+      const px = applyCalHeight();         // set height AFTER visible
+
       if (!fc) {
         fc = new FullCalendar.Calendar(calendarEl, {
           ...calendarOptions,

--- a/public/styles.css
+++ b/public/styles.css
@@ -1491,7 +1491,7 @@ body.modal-open { overflow: hidden; }
   margin: 0 auto; padding: 12px; border-radius: 12px;
 }
 
-/* calendar box grows; no %/auto fights */
+/* calendar box grows; height set via JS before render */
 #calendar {
   flex: 1;
   min-height: 0;


### PR DESCRIPTION
## Summary
- Ensure calendar height is applied after modal becomes visible
- Remove percentage height fallback from FullCalendar options
- Clarify that calendar box height is set via JavaScript

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bdab0803cc832184c60707ca8ec0b2