### PR TITLE
Defer FullCalendar rendering until after modal paint

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -3679,8 +3679,10 @@ SessionStore.onChange(refresh);
         });
         window._fcCalendar = fc;
       }
-      fc.render();
-      fc.updateSize();
+      requestAnimationFrame(() => {
+        fc.render();
+        fc.updateSize();
+      });
 
       // keep sizing correct while modal is open
       if (!onCalResize) {


### PR DESCRIPTION
## Summary
- Defer FullCalendar render and size to a second animation frame so the modal paints before the calendar grid.

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb9eb04508321bb1f9b17f6b7160b