### PR TITLE
Fix mobile FullCalendar display in modal

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1490,7 +1490,9 @@ body.modal-open { overflow: hidden; }
   display: flex;
   flex-direction: column;
   width: min(920px, 96vw);
-  height: 100svh; /* safe viewport height */
+  /* Fallback for browsers without svh support */
+  height: 100vh;
+  height: 100svh; /* safe viewport height when supported */
   margin: 0 auto;
   padding: 12px;
   border-radius: 12px;


### PR DESCRIPTION
## Summary
- ensure calendar modal uses a fallback height for browsers without `svh`
- keeps FullCalendar day grid visible on mobile when opening the modal

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bdbb62a5d88321b5134948d742b747