### PR TITLE
Fix FullCalendar modal rendering on iOS

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -3682,6 +3682,10 @@ SessionStore.onChange(refresh);
       requestAnimationFrame(() => {
         fc.render();
         fc.updateSize();
+        // iOS Safari sometimes renders the header but not the grid when the
+        // calendar is initialized in a just-shown modal. A second update on the
+        // next task ensures the day grid is drawn.
+        setTimeout(() => fc.updateSize(), 50);
       });
 
       // keep sizing correct while modal is open


### PR DESCRIPTION
## Summary
- Ensure calendar grid renders when modal opens on iOS by forcing a second updateSize call

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbcda84e08321bd5f664f1fb2369b