### PR TITLE
Fix calendar grid blank on mobile portrait

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -3683,9 +3683,9 @@ SessionStore.onChange(refresh);
         fc.render();
         fc.updateSize();
         // iOS Safari sometimes renders the header but not the grid when the
-        // calendar is initialized in a just-shown modal. A second update on the
-        // next task ensures the day grid is drawn.
-        setTimeout(() => fc.updateSize(), 50);
+        // calendar is initialized in a just-shown modal. A second render/update
+        // shortly after ensures the day grid is drawn in portrait mode.
+        setTimeout(() => { fc.render(); fc.updateSize(); }, 50);
       });
 
       // keep sizing correct while modal is open


### PR DESCRIPTION
## Summary
- Ensure FullCalendar calendar re-renders shortly after modal open to draw day grid in portrait mode on mobile

## Testing
- `npm test` *(fails: Missing script "test"*)

------
https://chatgpt.com/codex/tasks/task_e_68bdbe3082e08321ba093a1f11e5a525