### PR TITLE
Make calendar modal responsive like KPI modals

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -660,7 +660,7 @@
         </div>
       </div>
     </div>
-  <div id="calendarModal" hidden>
+  <div id="calendarModal" role="dialog" aria-modal="true" hidden>
     <div class="calendar-content">
       <button id="calendarClose" aria-label="Close">&times;</button>
       <select id="calendarFarmFilter"></select>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -3651,70 +3651,21 @@ SessionStore.onChange(refresh);
 
   let fc = window._fcCalendar || null;
 
-  function getCalHeightPx() {
-    const vh = (window.visualViewport?.height || window.innerHeight);
-    return Math.max(480, Math.floor(vh * 0.88)); // ~88% viewport, min 480px
-  }
-
-  function applyCalHeight() {
-    const px = getCalHeightPx();
-    calendarEl.style.height = px + 'px';   // element height
-    if (fc) fc.setOption('height', px);    // FullCalendar height
-    return px;
-  }
-
-  function renderCalendarWhenReady(calendarEl, calendarInstance) {
-    let tries = 0;
-    (function tick() {
-      const h = calendarEl.getBoundingClientRect().height;
-      if (h > 120) {
-        calendarInstance.render();
-        calendarInstance.updateSize();
-        attachObserver();
-      } else if (tries++ < 30) {
-        requestAnimationFrame(() => requestAnimationFrame(tick));
-      } else {
-        calendarInstance.render();
-        calendarInstance.updateSize();
-        attachObserver();
-      }
-    })();
-
-    function attachObserver() {
-      if ('ResizeObserver' in window) {
-        const ro = new ResizeObserver(() => {
-          applyCalHeight();
-          calendarInstance.updateSize();
-        });
-        ro.observe(calendarEl);
-      } else {
-        window.addEventListener('resize', () => {
-          applyCalHeight();
-          calendarInstance.updateSize();
-        });
-      }
-    }
-  }
-
   function openCalendarModal() {
     document.body.classList.add('modal-open');
     modal.hidden = false;                  // [hidden] → visible
 
-    const px = applyCalHeight();         // set height after visible
-
     if (!fc) {
       fc = new FullCalendar.Calendar(calendarEl, {
         ...calendarOptions,
-        height: px,
-        expandRows: true,
-        handleWindowResize: false       // we will manage resizing
+        height: 'auto',
+        expandRows: true
       });
       window._fcCalendar = fc;
+      fc.render();
     } else {
-      fc.setOption('height', px);
+      fc.updateSize();
     }
-
-    renderCalendarWhenReady(calendarEl, fc);
   }
 
   function closeCalendarModal() {

--- a/public/styles.css
+++ b/public/styles.css
@@ -1477,10 +1477,9 @@ button {
   position: fixed;
   inset: 0;
   z-index: 9999;
-  display: flex;
-  align-items: stretch;
-  justify-content: center;
-  background: rgba(0,0,0,0.6);
+  display: grid;
+  place-items: center;
+  background: rgba(0,0,0,0.5);
 }
 
 body.modal-open { overflow: hidden; }
@@ -1489,14 +1488,15 @@ body.modal-open { overflow: hidden; }
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  width: min(920px, 96vw);
-  /* Fallback for browsers without svh support */
-  height: 100vh;
-  height: 100svh; /* safe viewport height when supported */
-  margin: 0 auto;
+  width: min(960px, 92vw);
+  max-height: 86vh;
+  overflow: auto;
   padding: 12px;
+  background: var(--panel-bg, #0e0e0e);
+  color: var(--text-color, #f5f5f5);
   border-radius: 12px;
-  background: #111; /* match theme */
+  border: 1px solid var(--border-color, #2c2c2c);
+  box-shadow: 0 12px 30px rgba(0,0,0,.5);
 }
 
 #calendar {


### PR DESCRIPTION
## Summary
- Restyle calendar modal with responsive CSS and add dialog semantics
- Simplify calendar JS to remove manual height management and rely on auto sizing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bdc62ad0248321b6724b50572472a7