### PR TITLE
Align calendar modal with standard KPI modal layout

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -660,10 +660,15 @@
         </div>
       </div>
     </div>
-  <div id="kpiCalendarModal" role="dialog" aria-modal="true" hidden>
-    <div class="calendar-content">
-      <button id="kpiCalendarClose" aria-label="Close">&times;</button>
-      <select id="kpiCalendarFarmFilter"></select>
+  <div id="kpiCalendarModal" class="kpi-modal" role="dialog" aria-modal="true" aria-labelledby="kpiCalendarTitle" hidden>
+    <div class="kpi-modal-card">
+      <header class="kpi-modal-header">
+        <h2 id="kpiCalendarTitle">Calendar</h2>
+        <button class="kpi-close" id="kpiCalendarClose" aria-label="Close">✕</button>
+      </header>
+      <div class="kpi-controls">
+        <select id="kpiCalendarFarmFilter"></select>
+      </div>
       <div id="kpiCalendarGrid" class="calendar-container"></div>
     </div>
   </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1471,30 +1471,10 @@ button {
 }
 
 /* === Calendar Modal === */
-#kpiCalendarModal[hidden] { display: none !important; }
-
-#kpiCalendarModal {
-  position: fixed;
-  inset: 0;
-  z-index: 9999;
-  display: grid;
-  place-items: center;
-  background: rgba(0,0,0,0.5);
-}
-
-#kpiCalendarModal .calendar-content {
-  box-sizing: border-box;
+#kpiCalendarModal .kpi-modal-card {
   display: flex;
   flex-direction: column;
-  width: min(960px, 92vw);
-  max-height: 86vh;
-  overflow: auto;
-  padding: 12px;
-  background: var(--panel-bg, #0e0e0e);
-  color: var(--text-color, #f5f5f5);
-  border-radius: 12px;
-  border: 1px solid var(--border-color, #2c2c2c);
-  box-shadow: 0 12px 30px rgba(0,0,0,.5);
+  height: 86vh;
 }
 
 #kpiCalendarGrid {


### PR DESCRIPTION
## Summary
- Rework calendar modal markup to use shared `kpi-modal`/`kpi-modal-card` structure and add accessible header and close button
- Use flex column layout with explicit height so the FullCalendar grid can expand like the Total Hours modal
- Simplify calendar modal CSS and rely on global modal styles

## Testing
- `npm test` *(fails: Missing script "test" as no tests are defined)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcb8f0e24832185fa708cdda02a10