### PR TITLE
style: darken list view headers and add date badges

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -4000,15 +4000,19 @@ SessionStore.onChange(refresh);
   if (SessionStore.getAll().length) refresh();
 })();
 
-// === Calendar Modal (KPI-style) ===
+//// BEGIN:CALENDAR:JS ////
 (function(){
+  console.log('[Calendar] init block start');
   const btn = document.getElementById('kpiCalendar');
   const modal = document.getElementById('calendarModal');
   const btnCloseX = document.getElementById('calendarClose');
   const btnCloseFooter = document.getElementById('calendarCloseFooter');
   const host = document.getElementById('calendarHost');
 
-  if (!btn || !modal || !host) return;
+  if (!btn || !modal || !host) {
+    console.warn('[Calendar] Required elements not found (btn/modal/host).');
+    return;
+  }
 
   let calendar = null;
   let unlisten = null;
@@ -4019,16 +4023,18 @@ SessionStore.onChange(refresh);
     host.style.height = h + 'px';
   }
 
+  // Convert sessions to FullCalendar events
   function sessionsToEvents(docs){
     const events = [];
     for (const doc of (docs || [])) {
-      const s = (typeof doc.data === 'function') ? doc.data() : doc.data;
-      const ymd = getSessionDateYMD(s);
+      const s = (typeof doc?.data === 'function') ? doc.data() : doc?.data;
+      if (!s) continue;
+      const ymd = (typeof getSessionDateYMD === 'function') ? getSessionDateYMD(s) : null;
       if (!ymd) continue;
-      const farm = pickFarmName(s);
-      const sheep = sumSheep(s);
+      const farm = (typeof pickFarmName === 'function') ? pickFarmName(s) : 'Farm';
+      const sheep = (typeof sumSheep === 'function') ? sumSheep(s) : 0;
       events.push({
-        title: `${farm} — ${sheep.toLocaleString()} sheep`,
+        title: `${farm} — ${Number(sheep).toLocaleString()} sheep`,
         start: ymd,
         allDay: true,
         extendedProps: { farm, sheep, raw: s }
@@ -4037,28 +4043,67 @@ SessionStore.onChange(refresh);
     return events;
   }
 
+  // Add numeric date badges to list view headers and dark theme polish
+  function decorateListHeaders(){
+    if (!calendar) return;
+    // Only for list views
+    const viewType = calendar.view?.type || '';
+    if (!/list/.test(viewType)) return;
+
+    const cushions = host.querySelectorAll('.fc-list-day-cushion');
+    cushions.forEach(cushion => {
+      // Remove old badge if present (idempotent)
+      cushion.querySelectorAll('.fc-daynum-badge').forEach(b => b.remove());
+
+      // Anchor usually carries the date attr
+      const a = cushion.querySelector('a[data-date]') || cushion.querySelector('a');
+      const dateStr = a?.getAttribute?.('data-date');
+      if (!dateStr) return;
+
+      const d = new Date(dateStr);
+      if (isNaN(d)) return;
+      const dayNum = d.getDate();
+
+      const badge = document.createElement('span');
+      badge.className = 'fc-daynum-badge';
+      badge.textContent = String(dayNum);
+
+      // Insert badge at the start of the cushion content
+      cushion.firstChild ? cushion.insertBefore(badge, cushion.firstChild) : cushion.appendChild(badge);
+    });
+  }
+
   function ensureCalendar(){
     if (calendar) return;
+    if (typeof FullCalendar === 'undefined') {
+      console.error('[Calendar] FullCalendar not loaded.');
+      return;
+    }
     calendar = new FullCalendar.Calendar(host, {
       initialView: (window.innerWidth < 640 ? 'listMonth' : 'dayGridMonth'),
-      headerToolbar: {
-        left: 'prev,next today',
-        center: 'title',
-        right: 'dayGridMonth,listMonth'
-      },
+      headerToolbar: { left: 'prev,next today', center: 'title', right: 'dayGridMonth,listMonth' },
       height: '100%',
       contentHeight: 'auto',
-      firstDay: 1,
+      firstDay: 1, // Monday (NZ)
       dayMaxEvents: true,
+      eventDisplay: 'block',
+      datesSet(){ // runs on initial render & when navigating months or changing views
+        decorateListHeaders();
+      },
+      viewDidMount(){ // extra safety
+        decorateListHeaders();
+      },
       eventClick(info){
         const e = info.event.extendedProps || {};
         alert(`${e.farm || 'Farm'}\n${(e.sheep||0).toLocaleString()} sheep\nDate: ${info.event.startStr}`);
       }
     });
+
+    // Seed with cached sessions if available
     try {
       const cached = (typeof SessionStore?.getAll === 'function') ? SessionStore.getAll() : [];
       calendar.addEventSource(sessionsToEvents(cached));
-    } catch (e) { console.warn('[Calendar] preload failed', e); }
+    } catch (e) { console.warn('[Calendar] preload events failed', e); }
   }
 
   function onResize(){
@@ -4067,32 +4112,48 @@ SessionStore.onChange(refresh);
       const want = (window.innerWidth < 640) ? 'listMonth' : 'dayGridMonth';
       if (calendar.view.type !== want) calendar.changeView(want);
       calendar.updateSize();
+      decorateListHeaders();
     }
   }
 
   function openCalendarModal(){
+    console.log('[Calendar] open');
     modal.hidden = false;
     document.body.style.overflow = 'hidden';
+
     computeHostHeight();
     requestAnimationFrame(() => {
       ensureCalendar();
-      calendar.render();
-      setTimeout(() => calendar.updateSize(), 40);
+      if (calendar) {
+        calendar.render();
+        setTimeout(() => {
+          calendar.updateSize();
+          decorateListHeaders();
+        }, 40); // iOS Safari safety tick
+      }
     });
+
+    // Live updates
     if (!unlisten && typeof SessionStore?.onChange === 'function') {
       unlisten = SessionStore.onChange(docs => {
         try {
-          calendar.removeAllEvents();
-          calendar.addEventSource(sessionsToEvents(docs));
-          calendar.updateSize();
-        } catch (e) { console.warn('[Calendar] update failed', e); }
+          const events = sessionsToEvents(docs);
+          if (calendar) {
+            calendar.removeAllEvents();
+            calendar.addEventSource(events);
+            calendar.updateSize();
+            decorateListHeaders();
+          }
+        } catch (e) { console.warn('[Calendar] onChange update failed', e); }
       });
     }
+
     window.addEventListener('resize', onResize, { passive:true });
     window.addEventListener('orientationchange', onResize, { passive:true });
   }
 
   function closeCalendarModal(){
+    console.log('[Calendar] close');
     modal.hidden = true;
     document.body.style.overflow = '';
     window.removeEventListener('resize', onResize);
@@ -4102,5 +4163,10 @@ SessionStore.onChange(refresh);
   btn.addEventListener('click', openCalendarModal);
   btnCloseX?.addEventListener('click', closeCalendarModal);
   btnCloseFooter?.addEventListener('click', closeCalendarModal);
-  modal.addEventListener('click', e => { if (e.target === modal) closeCalendarModal(); });
+  modal.addEventListener('click', (e)=>{
+    if (e.target === modal) closeCalendarModal();
+  });
+
+  console.log('[Calendar] init block ready');
 })();
+//// END:CALENDAR:JS ////

--- a/public/styles.css
+++ b/public/styles.css
@@ -1477,3 +1477,31 @@ button {
   max-height: 96vh;
 }
 
+/* BEGIN:CALENDAR:LISTVIEW:DARK+BADGE */
+.fc .fc-list-day { background: #111 !important; } /* header row container */
+.fc .fc-list-day-cushion {
+  background: #15181f !important;
+  color: #e5e9f2 !important;
+  border-bottom: 1px solid #1f2430 !important;
+}
+.fc .fc-list-table td { background: #0f1115 !important; color: #dfe6f1 !important; }
+
+.fc .fc-daynum-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  margin-right: 8px;
+  border-radius: 6px;
+  font-weight: 800;
+  font-size: 14px;
+  color: #0b0d12;
+  background: linear-gradient(180deg, #f0cd66, #b58b2a);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.35), inset 0 0 6px rgba(255,255,255,0.12);
+}
+@media (max-width: 360px){
+  .fc .fc-daynum-badge { width: 24px; height: 24px; font-size: 12px; margin-right: 6px; }
+}
+/* END:CALENDAR:LISTVIEW:DARK+BADGE */
+


### PR DESCRIPTION
## Summary
- darken FullCalendar list view header rows to match dark theme
- inject numeric date badges and reapply decoration on navigation or refresh

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68bddc0455a483218aaceee56d0d16e1