### PR TITLE
feat(calendar): show timed events in calendar list view

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1505,3 +1505,9 @@ button {
 }
 /* END:CALENDAR:LISTVIEW:DARK+BADGE */
 
+/* BEGIN:CALENDAR:LISTVIEW:HIDE-ALLDAY */
+/* Hide the "all-day" label/column in list view */
+.fc .fc-list-event-time {
+  display: none !important;
+}
+/* END:CALENDAR:LISTVIEW:HIDE-ALLDAY */


### PR DESCRIPTION
## Summary
- display session start/finish times as timed events
- show friendly "Workday — farm — sheep" titles for untimed sessions
- hide the "all-day" column in FullCalendar list view

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bddf12b718832181af3a84013ed42e