### PR TITLE
Add session details modal and wrap calendar event titles

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -489,6 +489,19 @@
           <footer class="kpi-actions">
             <button id="calendarCloseFooter">Close</button>
           </footer>
+      </div>
+    </div>
+
+      <div id="sessionDetailsModal" class="kpi-modal" hidden>
+        <div class="kpi-modal-card">
+          <header class="kpi-modal-header">
+            <h2 id="sessionDetailsTitle">Session Details</h2>
+            <button class="kpi-close" id="sessionDetailsClose">✕</button>
+          </header>
+          <div id="sessionDetailsBody"></div>
+          <footer class="kpi-actions">
+            <button id="sessionDetailsCloseFooter">Close</button>
+          </footer>
         </div>
       </div>
 

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -4108,8 +4108,18 @@ SessionStore.onChange(refresh);
       viewDidMount(){ decorateListHeaders(); },
       eventClick(info){
         const e = info.event.extendedProps || {};
-        const timeLine = e.hasTimes ? `${e.startStr || ''}–${e.finishStr || ''}\n` : '';
-        alert(`${timeLine}${e.farm || 'Farm'}\n${(e.sheep||0).toLocaleString()} sheep\nDate: ${e.ymd || info.event.startStr}`);
+        const fields = [
+          ['Date', e.ymd || '—'],
+          ['Farm', e.farm || '—'],
+          ['Sheep', (e.sheep ?? 0).toLocaleString()],
+          ['Start', e.startStr || '—'],
+          ['Finish', e.finishStr || '—'],
+          ['Type', e.hasTimes ? 'Timed' : 'Workday']
+        ];
+        document.getElementById('sessionDetailsBody').innerHTML =
+          fields.map(([k,v]) => `<div class="label">${k}</div><div class="value">${v}</div>`).join('');
+        document.getElementById('sessionDetailsModal').hidden = false;
+        document.body.style.overflow = 'hidden';
       }
     });
     try {
@@ -4174,3 +4184,7 @@ SessionStore.onChange(refresh);
   console.log('[Calendar] init block ready');
 })();
 //// END:CALENDAR:JS ////
+
+document.getElementById('sessionDetailsClose')?.addEventListener('click',()=>{document.getElementById('sessionDetailsModal').hidden=true;document.body.style.overflow='';});
+document.getElementById('sessionDetailsCloseFooter')?.addEventListener('click',()=>{document.getElementById('sessionDetailsModal').hidden=true;document.body.style.overflow='';});
+document.getElementById('sessionDetailsModal').addEventListener('click',(e)=>{if(e.target.id==='sessionDetailsModal'){e.currentTarget.hidden=true;document.body.style.overflow='';}});

--- a/public/styles.css
+++ b/public/styles.css
@@ -1511,3 +1511,22 @@ button {
   display: none !important;
 }
 /* END:CALENDAR:LISTVIEW:HIDE-ALLDAY */
+
+/* Wrap event titles */
+.fc .fc-list-event-title a,
+.fc .fc-daygrid-event .fc-event-title {
+  white-space: normal !important;
+  word-break: break-word !important;
+  overflow-wrap: anywhere !important;
+  line-height: 1.3;
+}
+
+/* Session details modal layout */
+#sessionDetailsBody {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 6px 12px;
+}
+#sessionDetailsBody .label { font-weight: 600; color: #aaa; }
+#sessionDetailsBody .value { color: #eee; }
+


### PR DESCRIPTION
## Summary
- Allow long calendar event titles to wrap in list and month views
- Add modal to display session details on calendar event click
- Provide close controls for the session details modal

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bde29898b08321b8484248d844f6bc