### PR TITLE
Make calendar modal fill viewport

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -481,9 +481,8 @@
             <button class="kpi-close" id="calendarClose" aria-label="Close">✕</button>
           </header>
 
-          <!-- Fixed-height host solved via JS, avoids zero-height measurements -->
-          <div id="calendarShell" style="width:100%;max-width:100%;overflow:hidden;">
-            <div id="calendarHost" style="height:420px;"></div>
+          <div id="calendarShell">
+            <div id="calendarHost"></div>
           </div>
 
           <footer class="kpi-actions">

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -4018,9 +4018,7 @@ SessionStore.onChange(refresh);
   let unlisten = null;
 
   function computeHostHeight(){
-    const chrome = 180;
-    const h = Math.max(360, Math.floor(window.innerHeight - chrome));
-    host.style.height = h + 'px';
+    host.style.height = '100%';
   }
 
   function atTime(ymd, hhmm){

--- a/public/styles.css
+++ b/public/styles.css
@@ -1472,9 +1472,26 @@ button {
 
 /* Calendar modal sizing */
 #calendarModal .kpi-modal-card {
-  max-width: 1000px;
-  width: min(96vw, 1000px);
-  max-height: 96vh;
+  margin: 0;
+  width: 100vw;
+  height: 100vh;
+  max-width: none;
+  max-height: none;
+  display: flex;
+  flex-direction: column;
+}
+
+#calendarShell {
+  flex: 1 1 auto;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+#calendarHost {
+  width: 100%;
+  height: 100%;
 }
 
 /* BEGIN:CALENDAR:LISTVIEW:DARK+BADGE */


### PR DESCRIPTION
## Summary
- Stretch calendar modal to full viewport with flex layout
- Expand calendar container to occupy entire modal body
- Ensure calendar host uses 100% height for accurate sizing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bde76b8acc83219200e6f6ff723ef4