### PR TITLE
Fix calendar hours worked display

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -4059,6 +4059,18 @@ SessionStore.onChange(refresh);
                   hoursStr = diff.toFixed(1).replace(/\.0$/, '') + 'h';
                 }
               }
+            } else if (typeof parseHours === 'function') {
+              const stDec = parseHours(st);
+              const ftDec = parseHours(ft);
+              if (isFinite(stDec) && isFinite(ftDec)) {
+                let diff = ftDec - stDec;
+                if (diff < 0) diff += 24; // wrap past midnight
+                if (diff > 0) {
+                  hoursStr = typeof hoursToHM === 'function'
+                    ? hoursToHM(diff)
+                    : diff.toFixed(1).replace(/\.0$/, '') + 'h';
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary
- compute session hours for calendar events when only time strings are provided

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68be4adc6e388321820b5c7638e017c2