### PR TITLE
Bump service worker cache version to v18

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,5 +1,5 @@
 // ✅ Bump the cache version whenever you change this file or add new assets
-const CACHE_NAME = 'sheariq-pwa-v17';
+const CACHE_NAME = 'sheariq-pwa-v18';
 const FIREBASE_CDN_CACHE = 'firebase-cdn';
 
 


### PR DESCRIPTION
## Summary
- Increase service worker CACHE_NAME to `sheariq-pwa-v18` so clients fetch new cache

## Testing
- `npm test` (fails: Missing script "test")
- `firebase deploy` (fails: command not found; firebase-tools installation blocked)


------
https://chatgpt.com/codex/tasks/task_e_68be5d00db048321be37ce37a5ef12b0