### PR TITLE
chore: add cache-busting query params

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -25,13 +25,13 @@
 
   <!-- Preload main stylesheet so styles are ready ASAP -->
   <!-- If the page already links to styles.css, add this JUST ABOVE that link -->
-  <link rel="preload" href="styles.css?v=readability2" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <noscript><link rel="stylesheet" href="styles.css?v=readability2"></noscript>
+  <link rel="preload" href="styles.css?v=readability3" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="styles.css?v=readability3"></noscript>
 
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Dashboard - SHEAR iQ</title>
-  <link rel="stylesheet" href="styles.css?v=readability2">
+  <link rel="stylesheet" href="styles.css?v=readability3">
   <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
@@ -680,7 +680,7 @@
     </div>
   </div>
 
-  <script type="module" src="dashboard.js"></script>
+  <script type="module" src="dashboard.js?v=2"></script>
   <div id="loading-overlay">
     <div class="circle-spinner"></div>
     <div>Authenticating… Please wait</div>


### PR DESCRIPTION
## Summary
- add query string version to dashboard.js to ensure updated assets load
- bump styles.css reference to readability3 for improved cache busting

## Testing
- `npm test` *(fails: Missing script "test")*
- `firebase deploy --only hosting` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be5dba4ea48321aaa8472d1b47751c