### PR TITLE
fix: update calendar selectors

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1512,8 +1512,8 @@ button {
 }
 
 /* FullCalendar list view: show Hours in the time column and remove the blue dot */
-#calendarHost .fc .fc-list-event-graphic { display: none !important; }  /* remove dot */
-#calendarHost .fc .fc-list-event-time {
+#calendarHost .fc-list-event-graphic { display: none !important; }  /* remove dot */
+#calendarHost .fc-list-event-time {
   display: table-cell !important;    /* keep the column visible */
   width: 72px;                        /* adjust if needed */
   text-align: right;
@@ -1521,6 +1521,6 @@ button {
   padding-left: 8px;
   padding-right: 12px;
 }
-#calendarHost .fc .fc-hours-cell { font-weight: 600; }
-#calendarHost .fc .fc-list-event-title { white-space: normal; width: auto !important; }
+#calendarHost .fc-hours-cell { font-weight: 600; }
+#calendarHost .fc-list-event-title { white-space: normal; width: auto !important; }
 


### PR DESCRIPTION
## Summary
- fix FullCalendar list view selectors to match rendered structure

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68be60e2259083219248001c1629e8bd