### PR TITLE
Stop calendar listener on modal close

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -4219,6 +4219,10 @@ SessionStore.onChange(refresh);
   }
 
   function closeCalendarModal(){
+    if (typeof unlisten === 'function') {
+      unlisten();
+      unlisten = null;
+    }
     console.log('[Calendar] close');
     modal.hidden = true;
     document.body.style.overflow = '';


### PR DESCRIPTION
## Summary
- stop calendar from listening to `SessionStore` after the modal closes to avoid stray rerenders

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68be65dafab883219bec254d2a8181df