### PR TITLE
Remove all-day label from calendar list view

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -4144,9 +4144,13 @@ SessionStore.onChange(refresh);
       viewDidMount(){ // extra safety
         decorateListHeaders();
       },
-      eventContent(info) {
+      // Remove "all-day" label in list views by injecting hours worked
+      eventDidMount(info) {
         if (info.view.type.includes('list')) {
-          return { timeText: info.event.extendedProps?.hoursWorked || '' };
+          const timeEl = info.el.querySelector('.fc-list-event-time');
+          if (timeEl) {
+            timeEl.textContent = info.event.extendedProps?.hoursWorked || '';
+          }
         }
       },
       eventClick(info){


### PR DESCRIPTION
## Summary
- Replace incorrect `eventContent` usage with `eventDidMount` to overwrite list view time cells, eliminating the default all-day label.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68be66f03d7c8321959fc7efee3cd3f6