### PR TITLE
Improve calendar modal sizing

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -483,7 +483,7 @@
 
           <!-- Fixed-height host solved via JS, avoids zero-height measurements -->
           <div id="calendarShell" style="width:100%;max-width:100%;overflow:hidden;">
-            <div id="calendarHost" style="height:420px;"></div>
+            <div id="calendarHost" style="height:420px;width:100%;"></div>
           </div>
 
           <footer class="kpi-actions">

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -4018,8 +4018,11 @@ SessionStore.onChange(refresh);
   let unlisten = null;
 
   function computeHostHeight(){
-    const chrome = 180; // header/footer space inside modal card
-    const h = Math.max(360, Math.floor(window.innerHeight - chrome));
+    const header = modal.querySelector('.kpi-modal-header');
+    const footer = modal.querySelector('.kpi-actions');
+    const chrome = (header?.offsetHeight || 0) + (footer?.offsetHeight || 0);
+    const cardMax = Math.floor(window.innerHeight * 0.96); // match card max-height
+    const h = Math.max(360, cardMax - chrome);
     host.style.height = h + 'px';
   }
 


### PR DESCRIPTION
## Summary
- expand calendar host width to fill modal
- compute dynamic calendar height based on header and footer sizes for full modal fit

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68be6b4312248321a81616225bb8a348