### PR TITLE
chore: stretch calendar list view to full width on mobile

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1505,6 +1505,11 @@ button {
 }
 /* END:CALENDAR:LISTVIEW:DARK+BADGE */
 
+/* Remove side margin so list view spans modal width on small screens */
+@media (max-width: 640px){
+  #calendarHost .fc { --fc-page-margin: 0; }
+}
+
 #calendarHost .fc .fc-list-table td,
 #calendarHost .fc .fc-list-table th {          /* tighten side gutters inside border */
   padding-left: 12px !important;


### PR DESCRIPTION
## Summary
- Remove FullCalendar's default page margin on small screens so list view rows span the entire modal width

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68be6d02784883218f7826acd70b863f