### PR TITLE
Ensure calendar list view fills modal width on mobile

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1527,5 +1527,5 @@ button {
   padding-right: 12px;
 }
 #calendarHost .fc-hours-cell { font-weight: 600; }
-#calendarHost .fc-list-event-title { white-space: normal; width: auto !important; }
+#calendarHost .fc-list-event-title { white-space: normal; width: 100% !important; }
 


### PR DESCRIPTION
## Summary
- Prevent event title column from shrinking by forcing full width so calendar uses available space

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68be6ef0d7b883219d929a14ca3e4933