### PR TITLE
feat: add year picker to calendar

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -481,6 +481,13 @@
             <button class="kpi-close" id="calendarClose" aria-label="Close">✕</button>
           </header>
 
+          <div class="kpi-controls">
+            <label>
+              Year
+              <select id="calendarYearSelect"></select>
+            </label>
+          </div>
+
           <!-- Fixed-height host solved via JS, avoids zero-height measurements -->
           <div id="calendarShell" style="width:100%;max-width:100%;overflow:hidden;">
             <div id="calendarHost" style="height:420px;width:100%;"></div>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -4036,14 +4036,25 @@ SessionStore.onChange(refresh);
   const btnCloseX = document.getElementById('calendarClose');
   const btnCloseFooter = document.getElementById('calendarCloseFooter');
   const host = document.getElementById('calendarHost');
+  const yearSel = document.getElementById('calendarYearSelect');
 
-  if (!btn || !modal || !host) {
-    console.warn('[Calendar] Required elements not found (btn/modal/host).');
+  if (!btn || !modal || !host || !yearSel) {
+    console.warn('[Calendar] Required elements not found (btn/modal/host/yearSel).');
     return;
   }
 
   let calendar = null;
   let unlisten = null;
+
+  fillYearsSelect(yearSel);
+
+  yearSel.addEventListener('change', () => {
+    const year = Number(yearSel.value);
+    if (calendar && !isNaN(year)) {
+      const month = calendar.getDate().getMonth();
+      calendar.gotoDate(new Date(year, month, 1));
+    }
+  });
 
   // Prefer existing parser if available
   const parseHours = (typeof window.parseHoursToDecimal === 'function')
@@ -4147,6 +4158,9 @@ SessionStore.onChange(refresh);
       allDayText: '', // remove label entirely
       datesSet(){ // runs on initial render & when navigating months or changing views
         decorateListHeaders();
+        if (yearSel && calendar) {
+          yearSel.value = String(calendar.getDate().getFullYear());
+        }
       },
       viewDidMount(){ // extra safety
         decorateListHeaders();


### PR DESCRIPTION
## Summary
- add year dropdown to sessions calendar modal
- sync calendar navigation with year dropdown

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68be8322d4a48321a3d05fd4b8bf3585