### PR TITLE
feat: add planner filter reset and button focus ring

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -503,6 +503,7 @@
               <label>To
                 <input type="month" id="fmYearTo">
               </label>
+              <button id="fmResetFilters" type="button">Reset Filters</button>
             </div>
 
             <div class="fm-panels">

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -4063,6 +4063,7 @@ SessionStore.onChange(refresh);
   const addBtn = document.getElementById('fmAddPlaceholders');
   const lockChk = document.getElementById('fmLockPast');
   const lockWrap = document.getElementById('fmLockWrapper');
+  const resetBtn = document.getElementById('fmResetFilters');
   const summaryBody = document.querySelector('#farmMonthsSummaryTable tbody');
   const plannerBody = document.querySelector('#farmMonthsPlannerTable tbody');
   const PREF_KEY = 'farmMonthsPrefs';
@@ -4187,6 +4188,14 @@ SessionStore.onChange(refresh);
       to: toInput.value
     };
     try { localStorage.setItem(PREF_KEY, JSON.stringify(p)); } catch(e){}
+  }
+
+  function updateFilterIndicators(){
+    if(farmSel) farmSel.classList.toggle('filter-active', farmSel.value !== '__ALL__');
+    if(sheepSel) sheepSel.classList.toggle('filter-active', sheepSel.value !== '__ALL__');
+    if(stationSel) stationSel.classList.toggle('filter-active', stationSel.value !== '__ALL__');
+    if(fromInput) fromInput.classList.toggle('filter-active', fromInput.value !== `${currentYear}-01`);
+    if(toInput) toInput.classList.toggle('filter-active', toInput.value !== `${currentYear}-12`);
   }
 
   function getEvents(){
@@ -4430,6 +4439,7 @@ SessionStore.onChange(refresh);
   function openCalendarModal(){
     console.log('[Calendar] open');
     loadPrefs();
+    updateFilterIndicators();
     showTab('calendar');
     modal.hidden = false;
     document.body.style.overflow = 'hidden';
@@ -4490,7 +4500,17 @@ SessionStore.onChange(refresh);
   genBtn?.addEventListener('click', generateDraft);
   addBtn?.addEventListener('click', addPlaceholders);
   lockChk?.addEventListener('change', renderPlannerTable);
-  [farmSel, sheepSel, stationSel, fromInput, toInput].forEach(el=>el?.addEventListener('change', ()=>{savePrefs();refreshActive();}));
+  [farmSel, sheepSel, stationSel, fromInput, toInput].forEach(el=>el?.addEventListener('change', ()=>{savePrefs();refreshActive();updateFilterIndicators();}));
+  resetBtn?.addEventListener('click', ()=>{
+    farmSel.value='__ALL__';
+    sheepSel.value='__ALL__';
+    stationSel.value='__ALL__';
+    fromInput.value=`${currentYear}-01`;
+    toInput.value=`${currentYear}-12`;
+    savePrefs();
+    updateFilterIndicators();
+    refreshActive();
+  });
 
   console.log('[Calendar] init block ready');
 })();

--- a/public/styles.css
+++ b/public/styles.css
@@ -1552,11 +1552,23 @@ button {
   border:1px solid var(--border-color, #2c2c2c);
   text-align:center;
 }
-.fm-table th {
+.fm-table th { 
   position:sticky;
   top:0;
   background:#1a1a1a;
   z-index:2;
+}
+
+/* Highlight buttons in planner tab when selected */
+#fmFilters button:focus-visible,
+#calPanel-planner button:focus-visible {
+  outline: 2px solid #22c55e;
+  outline-offset: 2px;
+}
+#fmFilters select.filter-active,
+#fmFilters input.filter-active {
+  outline: 2px solid #22c55e;
+  outline-offset: 2px;
 }
 .fm-table th:first-child { left:0; z-index:3; }
 .fm-table td:first-child {


### PR DESCRIPTION
## Summary
- add Reset Filters button for planner view
- highlight planner buttons and filters with green focus ring
- track active filter selections and allow clearing all filters

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68be974097f88321a2d563c570b86fe4