### PR TITLE
Show next year's draft plan title in planner tab

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -4037,9 +4037,10 @@ SessionStore.onChange(refresh);
   const btnCloseFooter = document.getElementById('calendarCloseFooter');
   const host = document.getElementById('calendarHost');
   const yearSel = document.getElementById('calendarYearSelect');
+  const titleEl = document.getElementById('calendarTitle');
 
-  if (!btn || !modal || !host || !yearSel) {
-    console.warn('[Calendar] Required elements not found (btn/modal/host/yearSel).');
+  if (!btn || !modal || !host || !yearSel || !titleEl) {
+    console.warn('[Calendar] Required elements not found (btn/modal/host/yearSel/title).');
     return;
   }
 
@@ -4358,6 +4359,10 @@ SessionStore.onChange(refresh);
     fmFilters.hidden = (id==='calendar');
     exportBtn.hidden = (id!=='summary');
     genBtn.hidden = addBtn.hidden = lockWrap.hidden = (id!=='planner');
+    if(titleEl){
+      if(id==='planner') titleEl.textContent = `Draft Plan for ${currentYear + 1}`;
+      else titleEl.textContent = 'Sessions Calendar';
+    }
     if(id==='summary') renderSummary();
     if(id==='planner') {
       if(!Object.keys(plannerData).length) generateDraft();


### PR DESCRIPTION
## Summary
- Dynamically update calendar header to "Draft Plan for <next year>" when the planner tab is active.
- Ensure calendar title element is required for the calendar module.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68be9f2245e88321b4886e9fe582008e