### PR TITLE
Add remove placeholders button to planner tab

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -552,6 +552,7 @@
               <button id="fmExportCSV" hidden>Export CSV</button>
               <button id="fmGenerate" hidden>Generate Draft Plan</button>
               <button id="fmAddPlaceholders" hidden>Add Placeholders</button>
+              <button id="fmRemovePlaceholders" hidden>Remove Placeholders</button>
               <label id="fmLockWrapper" class="fm-lock" hidden><input type="checkbox" id="fmLockPast"> Lock Past Months</label>
               <button id="calendarCloseFooter">Close</button>
             </footer>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -4061,6 +4061,7 @@ SessionStore.onChange(refresh);
   const exportBtn = document.getElementById('fmExportCSV');
   const genBtn = document.getElementById('fmGenerate');
   const addBtn = document.getElementById('fmAddPlaceholders');
+  const removeBtn = document.getElementById('fmRemovePlaceholders');
   const lockChk = document.getElementById('fmLockPast');
   const lockWrap = document.getElementById('fmLockWrapper');
   const resetBtn = document.getElementById('fmResetFilters');
@@ -4352,13 +4353,20 @@ SessionStore.onChange(refresh);
     });
   }
 
+  function removePlaceholders(){
+    if(!window.calendar){ alert('Calendar not ready'); return; }
+    window.calendar.getEvents().forEach(ev => {
+      if(ev.extendedProps?.draft) ev.remove();
+    });
+  }
+
   function showTab(id){
     calTabs.forEach(t=>t.classList.remove('is-active'));
     calTabs.forEach(t=>{ if(t.dataset.tab===id) t.classList.add('is-active'); });
     Object.keys(calPanels).forEach(k=>calPanels[k].hidden = (k!==id));
     fmFilters.hidden = (id==='calendar');
     exportBtn.hidden = (id!=='summary');
-    genBtn.hidden = addBtn.hidden = lockWrap.hidden = (id!=='planner');
+    genBtn.hidden = addBtn.hidden = removeBtn.hidden = lockWrap.hidden = (id!=='planner');
     if(titleEl){
       if(id==='planner') titleEl.textContent = `Draft Plan for ${currentYear + 1}`;
       else titleEl.textContent = 'Sessions Calendar';
@@ -4495,6 +4503,7 @@ SessionStore.onChange(refresh);
   exportBtn?.addEventListener('click', exportCSV);
   genBtn?.addEventListener('click', generateDraft);
   addBtn?.addEventListener('click', addPlaceholders);
+  removeBtn?.addEventListener('click', removePlaceholders);
   lockChk?.addEventListener('change', renderPlannerTable);
   [farmSel, sheepSel, fromInput, toInput].forEach(el=>el?.addEventListener('change', ()=>{savePrefs();refreshActive();updateFilterIndicators();}));
   resetBtn?.addEventListener('click', ()=>{


### PR DESCRIPTION
## Summary
- add Remove Placeholders button to planner view
- allow removing draft events from calendar

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bea453d76c832180f4998f85d405aa