### PR TITLE
Rename farm month summary tab and title

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -483,7 +483,7 @@
 
             <div class="fm-tabs">
               <button type="button" class="fm-tab is-active" data-tab="calendar">Calendar</button>
-              <button type="button" class="fm-tab" data-tab="summary">Summary</button>
+              <button type="button" class="fm-tab" data-tab="summary">Farm-by-Month yearly Summary</button>
               <button type="button" class="fm-tab" data-tab="planner">Planner</button>
             </div>
 

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -4343,6 +4343,7 @@ SessionStore.onChange(refresh);
     genBtn.hidden = lockWrap.hidden = (id!=='planner');
     if(titleEl){
       if(id==='planner') titleEl.textContent = `Draft Plan for ${currentYear + 1}`;
+      else if(id==='summary') titleEl.textContent = 'Farm-by-Month yearly Summary';
       else titleEl.textContent = 'Sessions Calendar';
     }
     if(id==='summary') renderSummary();


### PR DESCRIPTION
## Summary
- rename farm-month summary tab to "Farm-by-Month yearly Summary"
- update tab switching logic to display "Farm-by-Month yearly Summary" heading when summary tab is active

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bead843ed48321a1ab7e97f2b7a0a8