### PR TITLE
Rename summary tab to Yearly Calendar Overview

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -483,7 +483,7 @@
 
             <div class="fm-tabs">
               <button type="button" class="fm-tab is-active" data-tab="calendar">Calendar</button>
-              <button type="button" class="fm-tab" data-tab="summary">Farm-By-Month Yearly Summary</button>
+              <button type="button" class="fm-tab" data-tab="summary">Yearly Calendar Overview</button>
               <button type="button" class="fm-tab" data-tab="planner">Planner</button>
             </div>
 

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -4343,7 +4343,7 @@ SessionStore.onChange(refresh);
     genBtn.hidden = lockWrap.hidden = (id!=='planner');
     if(titleEl){
       if(id==='planner') titleEl.textContent = `Draft Plan for ${currentYear + 1}`;
-      else if(id==='summary') titleEl.textContent = 'Farm-By-Month Yearly Summary';
+      else if(id==='summary') titleEl.textContent = 'Yearly Calendar Overview';
       else titleEl.textContent = 'Sessions Calendar';
     }
     if(id==='summary') renderSummary();


### PR DESCRIPTION
## Summary
- Rename farm summary tab and calendar title to "Yearly Calendar Overview" for consistency.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68beafde55a88321bb0adaf4e0a5b71b