### PR TITLE
remove sheep type filter from dashboard calendar

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -491,9 +491,6 @@
               <label>Farm
                 <select id="fmFilterFarm"><option value="__ALL__">All farms</option></select>
               </label>
-              <label>Sheep type
-                <select id="fmFilterSheep"><option value="__ALL__">All types</option></select>
-              </label>
               <label>From
                 <input type="month" id="fmYearFrom">
               </label>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -4055,7 +4055,6 @@ SessionStore.onChange(refresh);
   };
   const fmFilters = document.getElementById('fmFilters');
   const farmSel = document.getElementById('fmFilterFarm');
-  const sheepSel = document.getElementById('fmFilterSheep');
   const fromInput = document.getElementById('fmYearFrom');
   const toInput = document.getElementById('fmYearTo');
   const exportBtn = document.getElementById('fmExportCSV');
@@ -4169,7 +4168,6 @@ SessionStore.onChange(refresh);
     try {
       const p = JSON.parse(localStorage.getItem(PREF_KEY) || '{}');
       if(p.farm) farmSel.value = p.farm;
-      if(p.sheep) sheepSel.value = p.sheep;
       fromInput.value = p.from || `${currentYear}-01`;
       toInput.value = p.to || `${currentYear}-12`;
     } catch(e){
@@ -4180,7 +4178,6 @@ SessionStore.onChange(refresh);
   function savePrefs(){
     const p = {
       farm: farmSel.value,
-      sheep: sheepSel.value,
       from: fromInput.value,
       to: toInput.value
     };
@@ -4189,7 +4186,6 @@ SessionStore.onChange(refresh);
 
   function updateFilterIndicators(){
     if(farmSel) farmSel.classList.toggle('filter-active', farmSel.value !== '__ALL__');
-    if(sheepSel) sheepSel.classList.toggle('filter-active', sheepSel.value !== '__ALL__');
     if(fromInput) fromInput.classList.toggle('filter-active', fromInput.value !== `${currentYear}-01`);
     if(toInput) toInput.classList.toggle('filter-active', toInput.value !== `${currentYear}-12`);
   }
@@ -4205,18 +4201,14 @@ SessionStore.onChange(refresh);
       if(y < fromYear || y > toYear) return false;
       const farm = e.extendedProps?.farm || e.extendedProps?.station || 'Unknown';
       if(farmSel.value !== '__ALL__' && farmSel.value !== farm) return false;
-      const type = e.extendedProps?.sheepType || '';
-      if(sheepSel.value !== '__ALL__' && sheepSel.value !== type) return false;
       return true;
     });
   }
 
   function populateFilters(events){
     const farms = new Set();
-    const sheepTypes = new Set();
     events.forEach(e => {
       if(e.extendedProps?.farm) farms.add(e.extendedProps.farm);
-      if(e.extendedProps?.sheepType) sheepTypes.add(e.extendedProps.sheepType);
     });
     function fill(sel, set){
       const cur = sel.value;
@@ -4227,7 +4219,6 @@ SessionStore.onChange(refresh);
       sel.value = cur || '__ALL__';
     }
     fill(farmSel, farms);
-    fill(sheepSel, sheepTypes);
   }
 
   function renderSummary(){
@@ -4478,10 +4469,9 @@ SessionStore.onChange(refresh);
   exportBtn?.addEventListener('click', exportCSV);
   genBtn?.addEventListener('click', generateDraft);
   lockChk?.addEventListener('change', renderPlannerTable);
-  [farmSel, sheepSel, fromInput, toInput].forEach(el=>el?.addEventListener('change', ()=>{savePrefs();refreshActive();updateFilterIndicators();}));
+  [farmSel, fromInput, toInput].forEach(el=>el?.addEventListener('change', ()=>{savePrefs();refreshActive();updateFilterIndicators();}));
   resetBtn?.addEventListener('click', ()=>{
     farmSel.value='__ALL__';
-    sheepSel.value='__ALL__';
     fromInput.value=`${currentYear}-01`;
     toInput.value=`${currentYear}-12`;
     savePrefs();


### PR DESCRIPTION
## Summary
- drop sheep type selector from dashboard calendar filters
- remove related sheep type preference and filtering logic

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68beb1b74f008321a1b34db860b1a61a