### PR TITLE
Load user profile on auth state change

### DIFF
--- a/public/auth.js
+++ b/public/auth.js
@@ -1,7 +1,9 @@
-firebase.auth().onAuthStateChanged(user => {
-  if (!user) {
-    window.location.href = 'login.html';
-  }
+firebase.auth().onAuthStateChanged(async (user) => {
+  if (!user) return window.location.replace('login.html');
+  const snap = await firebase.firestore().collection('users').doc(user.uid).get();
+  const data = snap.data() || {};
+  localStorage.setItem('contractor_id', data.contractorId);
+  if (data.mustChangePassword) window.location.replace('change-password.html');
 });
 
 export function handleLogout() {


### PR DESCRIPTION
## Summary
- Fetch user profile data on auth state change
- Store contractor id and redirect if password update needed

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf800c3ea4832187f48c141245d269