### PR TITLE
Add contractor-based Firestore security rules

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -13,6 +13,9 @@
       }
     ]
   },
+  "firestore": {
+    "rules": "firestore.rules"
+  },
   "functions": [
     {
       "source": "functions",

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,10 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{db}/documents {
+    match /contractors/{contractorId}/{document=**} {
+      allow read, write: if
+        request.auth != null &&
+        contractorId == get(/databases/$(db)/documents/users/$(request.auth.uid)).data.contractorId;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Firestore security rules restricting contractor document access to matching authenticated contractorId
- link new rules file in firebase.json configuration

## Testing
- `npm test` *(fails: Missing script "test")*
- `firebase deploy --only firestore:rules` *(fails: command not found and npm E403 when installing firebase-tools)*

------
https://chatgpt.com/codex/tasks/task_e_68bf88da6c3c8321a7c7ac31631c57df