### PR TITLE
Allow login for staff documents missing role

### DIFF
--- a/public/login.js
+++ b/public/login.js
@@ -147,14 +147,16 @@ document.addEventListener('DOMContentLoaded', () => {
       staffSnapshot.forEach((doc) => {
         const data = doc.data();
         console.log("Checking role:", data.role);
-        if (
-          data.email &&
-          data.email.toLowerCase() === userEmail.toLowerCase() &&
-          ((data.role || "").toLowerCase().trim() === "staff")
-        ) {
+
+        const emailsMatch =
+          data.email && data.email.toLowerCase() === userEmail.toLowerCase();
+        const role = (data.role || "").toLowerCase().trim();
+
+        if (emailsMatch && (role === "staff" || !data.role)) {
+          if (!data.role) {
+            console.warn("Role field missing in staff document:", doc.id);
+          }
           foundContractorId = data.contractorId;
-        } else if (!data.role) {
-          console.error("Role field missing in staff document:", doc.id);
         }
       });
 


### PR DESCRIPTION
## Summary
- Relax staff role check during login to accept records lacking a role field
- Warn when staff document is missing a role while still processing login

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf947059fc8321a220fb96bc5f060b