### PR TITLE
Add email fallback to contractor lookup in login

### DIFF
--- a/public/login.js
+++ b/public/login.js
@@ -140,6 +140,29 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
       }
 
+      // Fallback: search contractors collection by email
+      let contractorByEmailSnap = await db
+        .collection('contractors')
+        .where('email', '==', userEmail)
+        .limit(1)
+        .get();
+
+      if (contractorByEmailSnap.empty && userEmail.toLowerCase() !== userEmail) {
+        contractorByEmailSnap = await db
+          .collection('contractors')
+          .where('email', '==', userEmail.toLowerCase())
+          .limit(1)
+          .get();
+      }
+
+      if (!contractorByEmailSnap.empty) {
+        const contractorId = contractorByEmailSnap.docs[0].id;
+        await finalizeLogin('contractor', contractorId, uid);
+        await cacheStaffCanLoad(contractorId);
+        window.location.href = 'dashboard.html';
+        return;
+      }
+
       // Not a contractor - search staff subcollections across all contractors
       const staffSnapshot = await db.collectionGroup('staff').get();
       let foundContractorId = null;


### PR DESCRIPTION
## Summary
- Check `contractors/{uid}` for authenticated users
- Fall back to querying `contractors` by email before staff lookup

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf95776da88321aa2bd9b3958ee0db