### PR TITLE
Update staff login label and placeholder

### DIFF
--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -351,7 +351,8 @@
         <input type="text" id="staff-name" placeholder="Enter staff member’s name" required>
       </div>
       <div class="form-group">
-        <input type="email" id="staffEmailInput" placeholder="Email" required>
+        <label for="staffEmailInput">Staff Login</label>
+        <input type="email" id="staffEmailInput" placeholder="Enter login email (e.g. john.smith@contractor123)" required>
       </div>
       <div class="form-group">
         <input id="staffPersonalEmail" type="email" placeholder="Personal Email (optional)">


### PR DESCRIPTION
## Summary
- rename staff login input label to "Staff Login"
- clarify placeholder with example email for staff login

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bfa954bed4832182ea73b4cedf25ad