### PR TITLE
Replace alert popup with custom session modal

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -554,6 +554,17 @@
           </div>
         </div>
 
+        <div id="session-detail-modal" class="siq-modal" aria-hidden="true">
+          <div class="siq-modal__backdrop" data-close-modal></div>
+          <div class="siq-modal__panel">
+            <header class="siq-modal__header">
+              <h3>Session Details</h3>
+              <button class="siq-modal__close" data-close-modal aria-label="Close">&times;</button>
+            </header>
+            <div class="siq-modal__body" id="session-detail-body"></div>
+          </div>
+        </div>
+
 
         <div id="siq-widgets-grid">
         <!-- BEGIN: Top 5 Shearers Widget -->

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -4069,6 +4069,26 @@ SessionStore.onChange(refresh);
   const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
   const currentYear = new Date().getFullYear();
 
+  const detailModal = document.getElementById('session-detail-modal');
+  const detailBody = document.getElementById('session-detail-body');
+
+  function showSessionDetail(lines){
+    if (!detailModal || !detailBody){
+      alert(lines.join('\n'));
+      return;
+    }
+    detailBody.textContent = lines.join('\n');
+    detailModal.setAttribute('aria-hidden','false');
+  }
+
+  function hideSessionDetail(){
+    detailModal?.setAttribute('aria-hidden','true');
+  }
+
+  detailModal?.addEventListener('click', e => {
+    if (e.target.matches('[data-close-modal], .siq-modal__backdrop')) hideSessionDetail();
+  });
+
   fillYearsSelect(yearSel);
 
   yearSel.addEventListener('change', () => {
@@ -4384,7 +4404,7 @@ SessionStore.onChange(refresh);
         if (e.teamLeader) lines.push(`Team Leader: ${e.teamLeader}`);
         if (e.startTime) lines.push(`Start Time: ${e.startTime}`);
         if (e.finishTime) lines.push(`Finish Time: ${e.finishTime}`);
-        alert(lines.join('\n'));
+        showSessionDetail(lines);
       }
     });
     window.calendar = calendar;

--- a/public/styles.css
+++ b/public/styles.css
@@ -829,6 +829,50 @@ button {
 #shearers-modal .siq-rank-table th, #shedstaff-modal .siq-rank-table th,
 #shearers-modal .siq-rank-table td , #shedstaff-modal .siq-rank-table td { padding: 5px 7px; font-size: 0.9rem; }
 
+/* Session detail modal */
+#session-detail-modal.siq-modal {
+  position: fixed;
+  inset: 0;
+  display: none;
+  z-index: 10000;
+}
+#session-detail-modal[aria-hidden="false"] { display: block; }
+#session-detail-modal .siq-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,0.55);
+}
+#session-detail-modal .siq-modal__panel {
+  position: absolute;
+  right: 24px;
+  left: 24px;
+  top: 10vh;
+  margin: 0 auto;
+  max-width: 860px;
+  background: #0f1115;
+  border: 1px solid #21283a;
+  border-radius: 14px;
+  box-shadow: 0 18px 48px rgba(0,0,0,0.45);
+}
+#session-detail-modal .siq-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid #1b2130;
+}
+#session-detail-modal .siq-modal__body {
+  padding: 12px 16px 18px;
+  white-space: pre-line;
+}
+#session-detail-modal .siq-modal__close {
+  background: transparent;
+  border: none;
+  color: #c8d0e0;
+  font-size: 22px;
+  cursor: pointer;
+}
+
 /* Optional: allow more cards per row on desktop */
 #page-content .dash-grid {
   grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); /* was ~280px */


### PR DESCRIPTION
## Summary
- Add custom modal to display calendar session details
- Style new session detail modal
- Remove browser alert usage in calendar view

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bfe624faf08321b4417d145166b435