### PR TITLE
Improve heatmap contrast on dashboard

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1622,12 +1622,12 @@ button {
   text-align:left;
 }
 
-.heat-level-0 { background:#111; }
-.heat-level-1 { background:#1b1b1b; }
-.heat-level-2 { background:#252525; }
-.heat-level-3 { background:#2f2f2f; }
-.heat-level-4 { background:#393939; }
-.heat-level-5 { background:#434343; }
+.heat-level-0 { background:#1e3a8a; }
+.heat-level-1 { background:#2563eb; }
+.heat-level-2 { background:#16a34a; }
+.heat-level-3 { background:#facc15; color:#000; }
+.heat-level-4 { background:#fb923c; color:#000; }
+.heat-level-5 { background:#ef4444; color:#000; }
 
 .heatmap-legend {
   display:flex;


### PR DESCRIPTION
## Summary
- Replace single-hue heatmap with multi-colored palette for clearer contrast on dark background
- Keep high heat levels using black text for readability

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bfed74788c8321aae85afe9edaf0fd