### PR TITLE
style: use dark theme for no days heat map

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1622,7 +1622,7 @@ button {
   text-align:left;
 }
 
-.heat-level-0 { background:#1e3a8a; }
+.heat-level-0 { background:#111; }
 .heat-level-1 { background:#2563eb; }
 .heat-level-2 { background:#16a34a; }
 .heat-level-3 { background:#facc15; color:#000; }


### PR DESCRIPTION
## Summary
- revert `heat-level-0` style to dark theme color so empty days blend with the dashboard

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bfef8fec1c8321ad237f805248b79f