### PR TITLE
Move incident reporting into tally sheet sessions

### DIFF
--- a/public/tally.html
+++ b/public/tally.html
@@ -211,7 +211,6 @@
   <button class="tab-button active" data-view="tallySheetView">Tally Sheet</button>
   <button class="tab-button" data-view="summaryView" data-help="Welcome to the Daily Summary. This section provides you with a concise snapshot of the current day’s tally sheet. It’s designed to offer a straightforward numerical overview: you’ll see exactly how many sheep were shorn, categorized by type, and the total hours worked by shed staff. This summary focuses purely on the day’s output—no dates or team leader details—so you can quickly assess today’s performance at a glance. It's an efficient way to review daily progress before moving on to the next tasks.">Daily Summary</button>
   <button class="tab-button" data-view="stationSummaryView" data-help="Summarize a farm across dates or all time.">Farm Summary</button>
-  <button class="tab-button" data-view="incidentView">Incident Report</button>
   <button id="back-to-dashboard-btn" class="tab-button" style="display: none;" data-help="Go back to the Contractor Dashboard.">Return to Dashboard</button>
   </div>
 <div id="tallySheetView" class="view" data-help="Welcome to the Tally Sheet — the engine room of SHEΔR iQ. This is where you capture all the key data from the shearing day. When you start a new session, a setup prompt appears where you choose how many shearers, how many tally rows per shearer, and how many shed staff are needed. You’ll also select whether the day follows an 8-hour or 9-hour schedule, and set the lunch break duration to match your team.<br/><br/>Each shearer has flexible tally input — not limited to just four runs. Add as many rows as needed to match how your team works. Every row records both the sheep tally and the sheep type. Below the tally table is the Shed Staff section, where you can enter total hours worked for each rousie, presser, or other support crew member.<br/><br/>Start and Finish times are used to automatically calculate hours worked. If someone works through a break (like lunch), simply enter their times and when prompted, confirm that they worked through — the app will add the appropriate time to their hours for you. You can also toggle between 24‑hour and 12‑hour time views depending on your preference.<br/><br/>All fields — including dropdowns like sheep types, team leaders, and comb types — can be typed into manually. Anything you enter will automatically be added to the dropdown list, saving it for future use.<br/><br/>When you tap Save, the system cleans up your data automatically — removing any empty rows or unused fields — so your exports stay tidy and professional. You can export to CSV instantly, or revisit and reload saved sessions at any time.">
@@ -312,6 +311,7 @@
     <button id="saveButton" data-help="Save your session (device or cloud)." onclick="saveData(true)">Save</button>
     <button id="loadSessionBtn" data-help="Load a previous session from device or cloud.">Load Session</button>
     <button id="returnTodayBtn" data-help="Bring back today's work if you loaded another session. We keep a backup and this restores it, then clears the backup." onclick="restoreTodaySession()">Return to Today’s Session</button>
+    <button id="incidentReportBtn" onclick="showView('incidentView')">Incident Report</button>
     <button onclick="showExportPrompt()">Export Data</button>
   </div>
 
@@ -485,10 +485,11 @@
         </tr>
       </tbody>
     </table>
-    <button id="addIncidentBtn" onclick="addIncident()">Add Incident</button>
-    <button id="removeIncidentBtn" onclick="removeIncident()">Remove Incident</button>
+      <button id="addIncidentBtn" onclick="addIncident()">Add Incident</button>
+      <button id="removeIncidentBtn" onclick="removeIncident()">Remove Incident</button>
+      <button onclick="showView('tallySheetView')">Back to Tally Sheet</button>
+    </div>
   </div>
-</div>
 
 <footer id="footer">Logged in as: <span id="userEmail">loading...</span></footer>
 


### PR DESCRIPTION
## Summary
- Move incident reporting into each tally session by removing the tab and adding an Incident Report button alongside session controls.
- Include a back button in the incident view for easy return to the tally sheet.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c0b3ca1a508321a6c13e49bdc2a281