### PR TITLE
Fix incident report page missing contractor ID fallback

### DIFF
--- a/public/incident-reports.js
+++ b/public/incident-reports.js
@@ -60,7 +60,13 @@ document.addEventListener('DOMContentLoaded', () => {
   backBtn?.addEventListener('click', () => window.history.back());
 
   async function loadIncidents() {
-    const contractorId = localStorage.getItem('contractor_id');
+    // Look up the current contractor. Fall back to the signed-in user if
+    // contractor_id isn't stored locally so the page works for contractors
+    // who haven't explicitly set the value.
+    const contractorId =
+      localStorage.getItem('contractor_id') ||
+      firebase.auth()?.currentUser?.uid ||
+      null;
     if (!contractorId) {
       render([]);
       return;


### PR DESCRIPTION
## Summary
- allow incident reports page to fall back to the signed-in user when `contractor_id` isn't in local storage

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c0bc1f1b7c83219a154583ae20df4f