### PR TITLE
Fix incident report loading and persistence

### DIFF
--- a/public/firebase-init.js
+++ b/public/firebase-init.js
@@ -13,7 +13,7 @@
     if (firebase.firestore) {
       const db = firebase.firestore();
       try {
-        await db.enableIndexedDbPersistence();
+        await db.enablePersistence();
         console.info('IndexedDB persistence enabled');
       } catch (err) {
         console.warn('Failed to enable persistence', err);

--- a/public/incident-reports.js
+++ b/public/incident-reports.js
@@ -60,14 +60,9 @@ document.addEventListener('DOMContentLoaded', () => {
   backBtn?.addEventListener('click', () => window.history.back());
 
   async function loadIncidents() {
-    // Look up the current contractor. Fall back to the signed-in user if
-    // contractor_id isn't stored locally so the page works for contractors
-    // who haven't explicitly set the value.
-    const contractorId =
-      localStorage.getItem('contractor_id') ||
-      firebase.auth()?.currentUser?.uid ||
-      null;
-    if (!contractorId) {
+    const user = firebase.auth().currentUser;
+    const contractorId = localStorage.getItem('contractor_id') || user?.uid || null;
+    if (!contractorId || !user) {
       render([]);
       return;
     }
@@ -96,5 +91,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  loadIncidents();
+  firebase.auth().onAuthStateChanged(() => {
+    loadIncidents();
+  });
 });


### PR DESCRIPTION
## Summary
- ensure Firestore persistence initialization uses the correct API
- defer incident loading until after auth is resolved

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c0bedffe5c8321916d05484fc129d2