### PR TITLE
Use custom modal for session load confirmation

### DIFF
--- a/public/tally.html
+++ b/public/tally.html
@@ -611,6 +611,17 @@ document.addEventListener('DOMContentLoaded', function () {
     </div>
   </div>
 
+<!-- Load Session Confirmation Modal -->
+<div id="loadSessionConfirmModal" class="modal-overlay">
+  <div class="modal-box">
+    <p id="loadSessionConfirmMessage" style="white-space: pre-line;"></p>
+    <div class="modal-buttons">
+      <button id="loadSessionConfirmYes">Load</button>
+      <button id="loadSessionConfirmNo">Cancel</button>
+    </div>
+  </div>
+</div>
+
 <script>
 document.addEventListener('DOMContentLoaded', function () {
   var modal = document.getElementById('resetModal');

--- a/public/tally.js
+++ b/public/tally.js
@@ -3180,8 +3180,26 @@ function startSessionLoader(session) {
     }
     confirmUnsavedChanges(() => {
         const summary = `Station: ${session.stationName}\nDate: ${formatDateNZ(session.date)}\nTeam Leader: ${session.teamLeader || ''}\n\nDo you want to load this session?`;
-        if (confirm(summary)) {
-            loadSessionObject(session);
+        const modal = document.getElementById('loadSessionConfirmModal');
+        const msgEl = document.getElementById('loadSessionConfirmMessage');
+        const yesBtn = document.getElementById('loadSessionConfirmYes');
+        const noBtn = document.getElementById('loadSessionConfirmNo');
+        if (modal && msgEl && yesBtn && noBtn) {
+            msgEl.textContent = summary;
+            modal.style.display = 'flex';
+            const cleanup = () => {
+                modal.style.display = 'none';
+                yesBtn.removeEventListener('click', onYes);
+                noBtn.removeEventListener('click', onNo);
+            };
+            const onYes = () => { cleanup(); loadSessionObject(session); };
+            const onNo = () => { cleanup(); };
+            yesBtn.addEventListener('click', onYes);
+            noBtn.addEventListener('click', onNo);
+        } else {
+            if (confirm(summary)) {
+                loadSessionObject(session);
+            }
         }
     });
 }


### PR DESCRIPTION
## Summary
- Add dedicated modal markup for confirming a session load
- Replace native `confirm` with custom modal logic in `tally.js`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c0c93ec5588321843a42904c014689