### PR TITLE
feat: notify unseen incident reports

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -157,6 +157,9 @@
         <img src="logo.png" alt="SHEΔR iQ logo" width="1125" height="927" />
         <h2 id="dashboard-heading">Contractor Dashboard</h2>
       </div>
+      <button id="incidentNotice" class="notification" hidden>
+        View incident reports
+      </button>
       <div class="dashboard-main">
         <p id="dashboard-subheading"></p>
         <!-- KPI BAR (new) -->

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -136,6 +136,35 @@ function throttle(ms, fn){
   let t=0; return (...a)=>{ const now=Date.now(); if (now-t>ms){ t=now; return fn(...a); } };
 }
 
+function checkIncidentNotifications(){
+  const btn = document.getElementById('incidentNotice');
+  if (!btn) return;
+  let sessions;
+  try {
+    sessions = JSON.parse(localStorage.getItem('sheariq_sessions') || '[]');
+    sessions = Array.isArray(sessions) ? sessions : [];
+  } catch (e) {
+    sessions = [];
+  }
+  const unseen = [];
+  sessions.forEach(s => {
+    if (Array.isArray(s.incidents) && s.incidents.length) {
+      const sessionKey = (s.date || '') + '_' + (s.stationName || '');
+      if (!localStorage.getItem('incident_seen_' + sessionKey)) {
+        unseen.push(sessionKey);
+      }
+    }
+  });
+  if (unseen.length) {
+    btn.hidden = false;
+    btn.textContent = 'View incident reports (' + unseen.length + ')';
+    btn.addEventListener('click', () => {
+      unseen.forEach(k => localStorage.setItem('incident_seen_' + k, '1'));
+      location.href = 'incident-reports.html';
+    }, { once: true });
+  }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const role = localStorage.getItem('user_role');
   if (role === 'contractor' && isReallyOffline()) {
@@ -162,6 +191,7 @@ document.addEventListener('DOMContentLoaded', () => {
       showOfflineToastOnce('Offline mode: cached navigation ready');
     }
   }));
+  checkIncidentNotifications();
 });
 
 // Auto-open on first dashboard load (only once)

--- a/public/incident-reports.js
+++ b/public/incident-reports.js
@@ -73,11 +73,14 @@ document.addEventListener('DOMContentLoaded', () => {
     try {
       const snap = await firebase.firestore().collection('contractors').doc(contractorId).collection('sessions').get();
       allIncidents = [];
+      const seenKeys = [];
       snap.forEach(doc => {
         const data = doc.data();
         const date = parseSessionDate(data);
         const station = data.stationName || '';
         if (Array.isArray(data.incidents)) {
+          const sessionKey = formatNZDate(date) + '_' + station;
+          if (data.incidents.length) seenKeys.push(sessionKey);
           data.incidents.forEach(i => {
             allIncidents.push({ date, station, time: i.time, name: i.name, description: i.description });
           });
@@ -89,6 +92,7 @@ document.addEventListener('DOMContentLoaded', () => {
         return bd - ad;
       });
       render(allIncidents);
+      seenKeys.forEach(k => localStorage.setItem('incident_seen_' + k, '1'));
     } catch (e) {
       console.error('Failed to load incidents', e);
       render([]);


### PR DESCRIPTION
## Summary
- add hidden notification button to dashboard
- show count of unseen incident reports from stored sessions
- clear incident notifications after viewing reports

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c0cec29f648321b5979f9ad7787361