### PR TITLE
feat: surface incident notice on dashboard

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -131,6 +131,7 @@
   </script>
 <!-- DASHBOARD HELP BUTTON -->
 <button id="help-btn" aria-haspopup="true" aria-expanded="false" aria-controls="dash-help-menu" title="Help">?</button>
+<button id="incidentNotice" class="notification">No incident reports</button>
 
 <!-- HELP MENU DROPDOWN -->
 <div id="dash-help-menu" role="dialog" aria-modal="false" aria-labelledby="dash-help-title" hidden>
@@ -157,9 +158,6 @@
         <img src="logo.png" alt="SHEΔR iQ logo" width="1125" height="927" />
         <h2 id="dashboard-heading">Contractor Dashboard</h2>
       </div>
-      <button id="incidentNotice" class="notification" hidden>
-        View incident reports
-      </button>
       <div class="dashboard-main">
         <p id="dashboard-subheading"></p>
         <!-- KPI BAR (new) -->

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -156,12 +156,15 @@ function checkIncidentNotifications(){
     }
   });
   if (unseen.length) {
-    btn.hidden = false;
+    btn.disabled = false;
     btn.textContent = 'View incident reports (' + unseen.length + ')';
     btn.addEventListener('click', () => {
       unseen.forEach(k => localStorage.setItem('incident_seen_' + k, '1'));
       location.href = 'incident-reports.html';
     }, { once: true });
+  } else {
+    btn.disabled = true;
+    btn.textContent = 'No incident reports';
   }
 }
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -963,6 +963,38 @@ button {
   transform: translateY(0);
 }
 
+/* Incident notification button */
+#incidentNotice {
+  position: fixed;
+  top: 12px;
+  right: 64px;
+  z-index: 9999;
+  padding: 8px 12px;
+  background: linear-gradient(135deg, #444, #222);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.4);
+  cursor: pointer;
+  transition: background 0.3s, transform 0.2s;
+}
+
+#incidentNotice:hover:not(:disabled) {
+  background: linear-gradient(135deg, #555, #333);
+  transform: translateY(-2px);
+}
+
+#incidentNotice:active:not(:disabled) {
+  background: linear-gradient(135deg, #333, #111);
+  transform: translateY(0);
+}
+
+#incidentNotice:disabled {
+  opacity: 0.5;
+  cursor: default;
+  transform: none;
+}
+
 /* Help menu: fixed to viewport with safe bounds */
 #tt-help-menu {
   position: fixed;


### PR DESCRIPTION
## Summary
- Move incident report notice button beside help button and show by default
- Update incident notification logic to toggle text and disabled state based on unseen reports
- Style incident notice to match help button and sit offset in top-right corner

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c0d373dfe88321b7fd8913ca8d37fb