### PR TITLE
Fix tally page locking on initial login

### DIFF
--- a/public/tally.js
+++ b/public/tally.js
@@ -3252,12 +3252,16 @@ document.addEventListener('DOMContentLoaded', () => {
     window.isLoadedSession = params.get('loadedSession') === 'true';
     const isNewDay = params.get('newDay') === 'true';
 
+    if (!window.isLoadedSession) {
+      // Fresh sessions should default to editable mode
+      try { localStorage.setItem('viewOnlyMode', 'false'); } catch (e) {}
+    }
     const viewOnlyMode = (localStorage.getItem('viewOnlyMode') || '').toLowerCase();
-    // If explicitly 'false', we allow editing (unlocked). Otherwise lock.
-    if (viewOnlyMode === 'false' || window.pinValidated === true) {
-      unlockSession();
-    } else {
+    // Only lock when explicitly in view-only mode and no valid PIN provided
+    if (viewOnlyMode === 'true' && window.pinValidated !== true) {
       lockSession();
+    } else {
+      unlockSession();
     }
 
     if (window.isLoadedSession) {


### PR DESCRIPTION
## Summary
- Default tally page sessions to editable when not loading a saved session
- Only apply view-only lock when `viewOnlyMode` is explicitly true and no contractor PIN has been validated

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c0d6cc5214832197285415f1c41413