### PR TITLE
Enable staff cloud session loading when permitted

### DIFF
--- a/public/tally.js
+++ b/public/tally.js
@@ -2755,7 +2755,7 @@ function buildExportRows(data) {
 
 function updateUIForRole(role) {
     const isContractor = role === 'contractor';
-    const ids = ['saveCloudBtn', 'saveBothBtn', 'loadCloudBtn'];
+    const ids = ['saveCloudBtn', 'saveBothBtn'];
     ids.forEach(id => {
         const el = document.getElementById(id);
         if (el) {
@@ -2763,6 +2763,14 @@ function updateUIForRole(role) {
             else el.setAttribute('disabled', 'disabled');
         }
     });
+    const loadCloudBtn = document.getElementById('loadCloudBtn');
+    if (loadCloudBtn) {
+        if (isContractor || (role === 'staff' && window.staffCanLoadSessions !== false)) {
+            loadCloudBtn.removeAttribute('disabled');
+        } else {
+            loadCloudBtn.setAttribute('disabled', 'disabled');
+        }
+    }
     const loadBtn = document.getElementById('loadSessionBtn');
     if (loadBtn) {
         if (role === 'staff' && window.staffCanLoadSessions === false) {


### PR DESCRIPTION
## Summary
- Allow staff to use the **Load from Cloud** button when `staffCanLoadSessions` is true
- Keep load button disabled only when staff have explicitly been denied access

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c0db52607c83219e4459368ec7ccbe