### PR TITLE
Reset incident report when tally session resets

### DIFF
--- a/public/tally.html
+++ b/public/tally.html
@@ -647,6 +647,10 @@ document.addEventListener('DOMContentLoaded', function () {
     var totalsBody = document.querySelector('#sheepTypeTotalsTable tbody');
     if (totalsBody) totalsBody.innerHTML = '';
     document.querySelectorAll('#shedStaffTable tr td:nth-child(2) input').forEach(function(el){ el.value = ''; });
+    var incidentBody = document.getElementById('incidentBody');
+    if (incidentBody) {
+      incidentBody.innerHTML = '<tr><td><input type="time" /></td><td><input type="text" placeholder="Name" /></td><td><textarea placeholder="Describe incident..."></textarea></td></tr>';
+    }
   }
 
   function performReset(full) {

--- a/public/tally.js
+++ b/public/tally.js
@@ -3073,12 +3073,16 @@ function resetTallySheet() {
     const subtotalRowEl = document.getElementById('subtotalRow');
     const staffTableEl = document.getElementById('shedStaffTable');
     const totalsBodyEl = document.querySelector('#sheepTypeTotalsTable tbody');
+    const incidentBodyEl = document.getElementById('incidentBody');
 
     if (headerRowEl) headerRowEl.innerHTML = '<th>Count #</th><th>Count Total</th><th class="sheep-type">Sheep Type</th>';
     if (bodyEl) bodyEl.innerHTML = '';
     if (subtotalRowEl) subtotalRowEl.innerHTML = '<th>Shearer Totals</th>';
     if (staffTableEl) staffTableEl.innerHTML = '';
     if (totalsBodyEl) totalsBodyEl.innerHTML = '';
+    if (incidentBodyEl) {
+        incidentBodyEl.innerHTML = '<tr><td><input type="time" /></td><td><input type="text" placeholder="Name" /></td><td><textarea placeholder="Describe incident..."></textarea></td></tr>';
+    }
 
     numStands = 0;
     runs = 0;


### PR DESCRIPTION
## Summary
- Clear incident entries when resetting tally sheet to ensure incidents don't carry over into new sessions.
- Reset incident table during general reset so fresh sessions start with a blank incident report.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c0e224cac48321a266ae6496d04908