### PR TITLE
feat: add tally export and incident buttons to tour

### DIFF
--- a/public/tally.html
+++ b/public/tally.html
@@ -311,8 +311,8 @@
     <button id="saveButton" data-help="Save your session (device or cloud)." onclick="saveData(true)">Save</button>
     <button id="loadSessionBtn" data-help="Load a previous session from device or cloud.">Load Session</button>
     <button id="returnTodayBtn" data-help="Bring back today's work if you loaded another session. We keep a backup and this restores it, then clears the backup." onclick="restoreTodaySession()">Return to Today’s Session</button>
-    <button id="incidentReportBtn" onclick="showView('incidentView')">Incident Report</button>
-    <button onclick="showExportPrompt()">Export Data</button>
+    <button id="incidentReportBtn" data-help="Log any accidents or incidents during this session." onclick="showView('incidentView')">Incident Report</button>
+    <button id="exportDataBtn" data-help="Export this tally sheet's data to CSV or Excel." onclick="showExportPrompt()">Export Data</button>
   </div>
 
 


### PR DESCRIPTION
## Summary
- include incident report button in tally guided tour
- include export data button in tally guided tour

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c0ebb7135c8321a77e1ae72680b6a8