### PR TITLE
Align PWA cache version and trigger SW updates

### DIFF
--- a/public/login.js
+++ b/public/login.js
@@ -2,7 +2,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const auth = firebase.auth();
   const db = firebase.firestore ? firebase.firestore() : null;
-  const CACHE_NAME = 'sheariq-pwa-v12';
+  // Keep this in sync with public/service-worker.js
+  const CACHE_NAME = 'sheariq-pwa-v19';
 
   async function finalizeLogin(role, contractorId, uid) {
     localStorage.setItem('user_role', role);

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,5 +1,5 @@
 // ✅ Bump the cache version whenever you change this file or add new assets
-const CACHE_NAME = 'sheariq-pwa-v18';
+const CACHE_NAME = 'sheariq-pwa-v19';
 const FIREBASE_CDN_CACHE = 'firebase-cdn';
 
 


### PR DESCRIPTION
## Summary
- Sync login.js cache version with service worker
- Bump service worker cache version and ensure skipWaiting/clientsClaim are used for updates

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c1287448c48321ac1c8ecca889038b