### PR TITLE
fix: safari compatibility

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -23,6 +23,13 @@ function markDashboardWelcomeSeen(){
   try { localStorage.setItem('dashboard_welcome_seen','true'); } catch(e){}
 }
 
+firebase.auth().onAuthStateChanged(function(user){
+  if (!user) {
+    window.location.replace('/login.html?v=' + Date.now());
+    return;
+  }
+});
+
 // If your app already exposes a function to open the dashboard welcome modal,
 // wrap it so it only opens once automatically. We leave a manual "force" path.
 (function(){
@@ -183,7 +190,7 @@ function checkIncidentNotifications(){
 async function refreshSessionsFromCloud(){
   try {
     const user = firebase.auth().currentUser;
-    const contractorId = localStorage.getItem('contractor_id') || user?.uid || null;
+    const contractorId = localStorage.getItem('contractor_id') || (user && user.uid) || null;
     if (!contractorId || !user) {
       checkIncidentNotifications();
       return;

--- a/public/firebase-init.js
+++ b/public/firebase-init.js
@@ -1,4 +1,4 @@
-(async function() {
+(function() {
   const firebaseConfig = {
     apiKey: "AIzaSyD529f2jn9mb8OAip4x6l3IQb7KOaPNxaM",
     authDomain: "sheariq-tally-app.firebaseapp.com",
@@ -11,12 +11,13 @@
   if (typeof firebase !== 'undefined' && (!firebase.apps || !firebase.apps.length)) {
     firebase.initializeApp(firebaseConfig);
     if (firebase.firestore) {
-      const db = firebase.firestore();
-      try {
-        await db.enablePersistence();
-        console.info('IndexedDB persistence enabled');
-      } catch (err) {
-        console.warn('Failed to enable persistence', err);
+      var db = firebase.firestore();
+      if (db && db.enablePersistence) {
+        db.enablePersistence().then(function() {
+          console.info('IndexedDB persistence enabled');
+        }).catch(function(err) {
+          console.warn('Failed to enable persistence', err);
+        });
       }
     }
   }

--- a/public/tally.js
+++ b/public/tally.js
@@ -106,9 +106,11 @@ if (localStorage.getItem('hours_modal_enabled') == null) localStorage.setItem('h
 if (localStorage.getItem('tally_autosave_mode') == null) localStorage.setItem('tally_autosave_mode','both');
 
 // ===== Help/Tour global runtime state (safe default) =====
+var _guidePref = localStorage.getItem('tally_guide_enabled');
+if (_guidePref === null || _guidePref === undefined) _guidePref = 'true';
 window.TT_STATE = window.TT_STATE || {
   tooltipsEnabled: false,
-  guideEnabled:    (localStorage.getItem('tally_guide_enabled') ?? 'true') === 'true',
+  guideEnabled: _guidePref === 'true',
 };
 
 function isSetupModalEnabled(){
@@ -135,7 +137,10 @@ window.renderHelpMenu = function () {
     </label>
     <button id="start" style="margin-top:8px;">Start guide now</button>
   `;
-  const gb = k => (localStorage.getItem(k) ?? 'true') === 'true';
+  var gb = function(k){
+    var v = localStorage.getItem(k);
+    return ((v === null || v === undefined ? 'true' : v) === 'true');
+  };
   const sb = (k,v) => localStorage.setItem(k, v ? 'true' : 'false');
   const tour = m.querySelector('#tour');
   const hoursModalToggle = m.querySelector('#hoursModalToggle');
@@ -150,7 +155,7 @@ window.renderHelpMenu = function () {
     <option value="cloud">Cloud</option>
     <option value="both">Both</option>
   </select>`;
-  start?.before(autosaveRow);
+  if (start) start.before(autosaveRow);
   const autosaveSelect = autosaveRow.querySelector('#autosaveMode');
   if (autosaveSelect){
     autosaveSelect.value = localStorage.getItem('tally_autosave_mode') || 'both';
@@ -166,7 +171,7 @@ window.renderHelpMenu = function () {
       <input type="checkbox" id="toggleSetupModal"> Enable Setup Day popup
     </label>
   `;
-  start?.before(setupToggleRow);
+  if (start) start.before(setupToggleRow);
   const toggleSetupBox = setupToggleRow.querySelector('#toggleSetupModal');
   if (toggleSetupBox){
     toggleSetupBox.checked = isSetupModalEnabled();


### PR DESCRIPTION
## Summary
- avoid Safari parsing issues by rewriting Firebase init to use promises
- guard dashboard access by redirecting unauthenticated users to login
- strip modern syntax from tally helpers for broader browser support

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c129e6e0648321854b10808b6c14ea