### PR TITLE
Fix welcome modal focus and prevent hidden menu clicks

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -2150,7 +2150,9 @@ document.addEventListener('DOMContentLoaded', () => {
     overlay.setAttribute('aria-hidden','false');
     lastFocused = document.activeElement;
     document.addEventListener('keydown', trapFocus);
-    setTimeout(() => ((btnOK && btnOK.focus)()), 0);
+    setTimeout(() => {
+      if (btnOK && btnOK.focus) btnOK.focus();
+    }, 0);
   }
 
   function closeWelcome() {

--- a/public/styles.css
+++ b/public/styles.css
@@ -656,8 +656,12 @@ button {
   inset: 0;
   display: none;
   z-index: 1000;
+  pointer-events: none;
 }
-#shearers-modal[aria-hidden="false"] , #shedstaff-modal[aria-hidden="false"] , #farms-full-modal[aria-hidden="false"] , #settings-modal[aria-hidden="false"] { display: block; }
+#shearers-modal[aria-hidden="false"] , #shedstaff-modal[aria-hidden="false"] , #farms-full-modal[aria-hidden="false"] , #settings-modal[aria-hidden="false"] {
+  display: block;
+  pointer-events: auto;
+}
 #shearers-modal .siq-modal__backdrop , #shedstaff-modal .siq-modal__backdrop , #farms-full-modal .siq-modal__backdrop , #settings-modal .siq-modal__backdrop {
   position: absolute;
   inset: 0;
@@ -1054,7 +1058,10 @@ button {
   box-shadow: 0 12px 28px rgba(0,0,0,0.5);
   z-index: 2147483001;
 }
-#dash-help-menu[hidden] { display: none; }
+#dash-help-menu[hidden] {
+  display: none;
+  pointer-events: none;
+}
 #dash-help-menu .dhm-header {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Guard focus call in welcome modal to avoid Illegal invocation error
- Disable pointer events for hidden menus and modals so they don't intercept clicks

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c136cd39dc8321ab4133781c35078d