### PR TITLE
feat: add farm data title to summary

### DIFF
--- a/public/tally.html
+++ b/public/tally.html
@@ -441,6 +441,7 @@
 <p id="stationNoData" class="message" style="margin-top:8px;">
   Select a farm and date range, or tick “All time for this farm”, then press Apply.
 </p>
+  <h2 id="farmDataTitle"></h2>
   <h3>Shearer Summary</h3>
   <table id="stationShearerTable" data-help="Totals per shearer for the selected period.">
     <thead><tr></tr></thead>

--- a/public/tally.js
+++ b/public/tally.js
@@ -2121,6 +2121,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const msgEl   = document.getElementById('stationNoData');
   const lastNInput = document.getElementById('lastNDaysInput');
   const lastNBtn   = document.getElementById('summaryApplyLastN');
+  const farmDataTitle = document.getElementById('farmDataTitle');
+
+  function updateFarmDataTitle() {
+    if (!farmDataTitle) return;
+    const farmName = farmSel?.selectedOptions[0]?.textContent?.trim() || '';
+    farmDataTitle.textContent = farmName ? `${farmName} — Farm Data` : '';
+  }
 
   // Keep farm list fresh on load (no auto-build)
   if (farmSel && typeof populateStationDropdown === 'function') {
@@ -2183,6 +2190,7 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
       }
       hideMsg();
+      updateFarmDataTitle();
       // Build summary now that inputs are valid
       if (typeof buildStationSummary === 'function') buildStationSummary();
     });
@@ -2199,6 +2207,7 @@ document.addEventListener('DOMContentLoaded', () => {
       showMsg('Select a farm and date range, or tick “All time for this farm”, then press Apply.');
     });
   }
+  updateFarmDataTitle();
 });
  
  function buildSummary() {


### PR DESCRIPTION
## Summary
- add `farmDataTitle` heading to Farm Summary view
- display selected farm name using new `updateFarmDataTitle` helper
- refresh the heading on load and when Apply is used

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c1529efa6c8321b39fedf93db4ef1c