### PR TITLE
Auto-fit farm summary export columns

### DIFF
--- a/public/tally.js
+++ b/public/tally.js
@@ -3517,7 +3517,7 @@ const interceptReset = (full) => (e) => {
 
     const exportBtn = document.getElementById('exportFarmSummaryBtn');
     exportBtn?.addEventListener('click', () => {
-        exportFarmSummaryCSV();
+        exportFarmSummary();
     });
 
     document.addEventListener('focusin', async (e) => {


### PR DESCRIPTION
## Summary
- Add Excel export for Farm Summary with automatic column width calculation
- Prompt user to choose CSV or Excel when exporting the Farm Summary

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c15572d6a88321b1381ad487cc25ef