### PR TITLE
Remove password field from Manage Staff

### DIFF
--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -358,10 +358,6 @@
         <input id="staffPersonalEmail" type="email" placeholder="Personal Email">
       </div>
       <div class="form-group">
-        <label for="new-password">New Password</label>
-        <input id="new-password" type="text" placeholder="Enter password" required>
-      </div>
-      <div class="form-group">
         <select id="staffRoleSelect">
           <option value="staff">staff</option>
         </select>

--- a/public/manage-staff.js
+++ b/public/manage-staff.js
@@ -281,7 +281,6 @@ async function restoreStaff(btn) {
           document.getElementById('staff-name').value = '';
           document.getElementById('staffEmailInput').value = '';
           document.getElementById('staffPersonalEmail').value = '';
-          document.getElementById('new-password').value = '';
           document.getElementById('staffRoleSelect').value = 'staff';
         });
       }
@@ -296,7 +295,6 @@ async function restoreStaff(btn) {
       const staffName = document.getElementById('staff-name').value.trim();
       const loginEmail = document.getElementById('staffEmailInput').value.trim();
       const personalEmail = document.getElementById('staffPersonalEmail').value.trim();
-      const password = document.getElementById('new-password').value.trim();
       const role = document.getElementById('staffRoleSelect').value;
       if (!staffName) {
         alert('Please enter a name');
@@ -306,17 +304,13 @@ async function restoreStaff(btn) {
         alert('Please enter an email address');
         return;
       }
-      if (!password || password.length < 6) {
-        alert('Temporary password must be at least 6 characters');
-        return;
-      }
 
-        console.log('Creating staff user with', { loginEmail, personalEmail, password });
+        console.log('Creating staff user with', { loginEmail, personalEmail });
 
         try {
           if (createOverlay) createOverlay.style.display = 'flex';
           const createStaffUser = httpsCallable(functions, 'createStaffUser');
-          const result = await createStaffUser({ loginEmail, personalEmail, password });
+          const result = await createStaffUser({ loginEmail, personalEmail });
           const uid = result.data.uid;
           console.log('Created staff user UID:', uid);
 
@@ -332,7 +326,7 @@ async function restoreStaff(btn) {
 
         console.log('Reached sendStaffCredentials function');
         console.log('Contractor email:', auth.currentUser?.email);
-        console.log('staffName:', staffName, 'loginEmail:', loginEmail, 'personalEmail:', personalEmail, 'password:', password);
+        console.log('staffName:', staffName, 'loginEmail:', loginEmail, 'personalEmail:', personalEmail);
 
         try {
           const sendStaffCredentials = httpsCallable(functions, 'sendStaffCredentials');
@@ -340,7 +334,6 @@ async function restoreStaff(btn) {
             staffName,
             loginEmail,
             personalEmail,
-            password,
             contractorEmail: auth.currentUser.email
           });
           console.log('Staff credentials email sent successfully:', response.data);


### PR DESCRIPTION
## Summary
- Remove temporary password input from Manage Staff form.
- Strip password handling from staff creation logic, relying on password reset emails instead.

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c6b067a6a88321b7bd1f08b4b3ae4d