### PR TITLE
Fix staff table action button labels overflowing

### DIFF
--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -320,6 +320,20 @@
       padding: 4px 8px;
     }
 
+    /* Ensure the action column buttons keep their labels on one line */
+    .staff-table td:last-child,
+    .staff-table th:last-child {
+      white-space: nowrap !important;
+      word-break: normal !important;
+      overflow-wrap: normal !important;
+    }
+
+    .staff-table .deleteStaffBtn,
+    .staff-table .restoreStaffBtn {
+      width: auto;
+      white-space: nowrap;
+    }
+
     /* Make the first column narrow only for the active staff table so
        the email column gets more space without affecting deleted staff */
     #staffTable th:first-child,


### PR DESCRIPTION
## Summary
- Prevent action column cells and buttons from wrapping, ensuring "Delete" and "Restore" labels fit properly

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c6c2496108832196ef99254c8153cf