### PR TITLE
Clarify staff login field placeholder

### DIFF
--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -366,7 +366,7 @@
       </div>
       <div class="form-group">
         <label for="staffEmailInput">Staff Login</label>
-        <input type="email" id="staffEmailInput" placeholder="Enter login email (e.g. john.smith@contractor123)" required>
+        <input type="email" id="staffEmailInput" placeholder="Auto-generated login email (e.g. john.smith@business.com)" required>
       </div>
       <div class="form-group">
         <input id="staffPersonalEmail" type="email" placeholder="Personal Email">


### PR DESCRIPTION
## Summary
- note that staff login emails are auto-generated from the staff name and contractor business

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c6c52e62108321a94f6a94b3fb190b