### PR TITLE
Fix remove button width in deleted staff table

### DIFF
--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -329,7 +329,8 @@
     }
 
     .staff-table .deleteStaffBtn,
-    .staff-table .restoreStaffBtn {
+    .staff-table .restoreStaffBtn,
+    .staff-table .removeDeletedStaffBtn {
       width: auto;
       white-space: nowrap;
     }


### PR DESCRIPTION
## Summary
- ensure deleted staff 'Remove' button doesn't stretch to full width by adding CSS override

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c6cac379148321b51cde5ee7a22388