### PR TITLE
Prevent wrapping of staff login emails in tables

### DIFF
--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -328,6 +328,14 @@
       overflow-wrap: normal !important;
     }
 
+    /* Keep long staff login emails on a single line */
+    .staff-table td:nth-child(3),
+    .staff-table th:nth-child(3) {
+      white-space: nowrap !important;
+      word-break: normal !important;
+      overflow-wrap: normal !important;
+    }
+
     .staff-table .deleteStaffBtn,
     .staff-table .restoreStaffBtn,
     .staff-table .removeDeletedStaffBtn {


### PR DESCRIPTION
## Summary
- Keep staff login emails on a single line in both active and deleted staff tables

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c6cec77fb08321bc90caca9e9214f9