### PR TITLE
Ensure login columns don't wrap in staff tables

### DIFF
--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -329,8 +329,10 @@
     }
 
     /* Keep long staff login emails on a single line */
-    .staff-table td:nth-child(3),
-    .staff-table th:nth-child(3) {
+    #staffTable td:nth-child(3),
+    #staffTable th:nth-child(3),
+    #deletedStaffTable td:nth-child(2),
+    #deletedStaffTable th:nth-child(2) {
       white-space: nowrap !important;
       word-break: normal !important;
       overflow-wrap: normal !important;


### PR DESCRIPTION
## Summary
- Keep staff login columns on a single line in both active and deleted staff tables

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c6d27859288321a42e14df517d5e25