### PR TITLE
Prevent wrapping in staff management tables

### DIFF
--- a/public/manage-staff.html
+++ b/public/manage-staff.html
@@ -311,12 +311,12 @@
       border-collapse: collapse;
     }
 
-    /* Prevent wrapping/overlap in table cells */
+    /* Keep headers and cells to a single line across all staff tables */
     .table-scroll .staff-table th,
     .table-scroll .staff-table td {
-      white-space: normal !important;
-      word-break: break-word !important;
-      overflow-wrap: anywhere !important;
+      white-space: nowrap;
+      word-break: normal;
+      overflow-wrap: normal;
       padding: 4px 8px;
     }
 


### PR DESCRIPTION
## Summary
- Keep all headers and cells in Manage Staff tables on one line to avoid wrapping across columns

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c6d586c9a48321b3792c40aeaebf05