### PR TITLE
Ensure Start New Day triggers setup modal

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -89,13 +89,13 @@ function handleStartNewDayClick(e){
   if (isReallyOffline()) {
     caches.match('/tally.html').then(res => {
       if (res) {
-        location.assign('/tally.html');
+        location.assign('/tally.html?newDay=true');
       } else {
         alert('Tally page not available offline. Please connect to the internet at least once to cache this page.');
       }
     });
   } else {
-    location.assign('/tally.html');
+    location.assign('/tally.html?newDay=true');
   }
 }
 

--- a/public/tally.js
+++ b/public/tally.js
@@ -3434,6 +3434,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     } else if (isNewDay) {
         resetForNewDay();
+        window.awaitingSetupPrompt = true;
     }
 
     const storedRole = sessionStorage.getItem('userRole');
@@ -3470,7 +3471,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const cloudSelect = document.getElementById('cloudSessionSelect');
     const cloudConfirmBtn = document.getElementById('loadCloudConfirmBtn');
     const cloudCancelBtn = document.getElementById('cancelCloudLoadBtn');
-    if (!layoutBuilt && !getLastSession()) {
+    if (isNewDay || (!layoutBuilt && !getLastSession())) {
         window.awaitingSetupPrompt = true;
     }
     bindSetupPromptEvents();


### PR DESCRIPTION
## Summary
- Pass a `newDay=true` flag when navigating from the dashboard to the tally page
- Reset state and force the setup modal when `newDay` is requested

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c7a95608948321b02a7d999be1e013